### PR TITLE
Proto 235: Update buttons to v3.0.0-beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ List of Elements with their current respective design version:
 | Typography | v2.0.0 |
 | Color | v2.1.0 |
 | Icons | v2.3.0 |
-| Buttons | v2.1.2 |
+| Buttons | v3.0.0 |
 | Inputs | v2.0.1 |
 | Grid | v1.0.0 |
 | Presentation Strategies | v1.0.0 |

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ List of Elements with their current respective design version:
 | Typography | v2.0.0 |
 | Color | v2.1.0 |
 | Icons | v2.3.0 |
-| Buttons | v3.0.0-beta.1 |
+| Buttons | v3.0.0-beta.2 |
 | Inputs | v2.0.1 |
 | Grid | v1.0.0 |
 | Presentation Strategies | v1.0.0 |

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ List of Elements with their current respective design version:
 | Typography | v2.0.0 |
 | Color | v2.1.0 |
 | Icons | v2.3.0 |
-| Buttons | v3.0.0 |
+| Buttons | v3.0.0-beta.1 |
 | Inputs | v2.0.1 |
 | Grid | v1.0.0 |
 | Presentation Strategies | v1.0.0 |

--- a/demo/demoPages/components/ButtonPage.js
+++ b/demo/demoPages/components/ButtonPage.js
@@ -13,7 +13,7 @@ const ButtonPage = () => (
             <h3>Props:</h3>
             <ul>
               <li>btnType:String === "primary", "cta", "default", "tertiary"</li>
-              <li>btnSize:String === "small", "large"</li>
+              <li>btnSize:String === "small", "large", "xlarge"</li>
               <li>btnIcon:Bool === true/false</li>
               <li>disabled</li>
             </ul>
@@ -67,6 +67,16 @@ const ButtonPage = () => (
           <p className="code">{'<Button btnSize="large">Large</Button>'}</p>
 
           <br />
+
+          <h3>xLarge Button:</h3>
+          <Button btnSize="xlarge">xLarge</Button>
+          <p className="code">{'<Button btnSize="xlarge">xLarge</Button>'}</p>
+
+          <br />
+
+          <h3>Primary xLarge Button:</h3>
+          <Button btnType="primary" btnSize="xlarge">Primary xLarge</Button>
+          <p className="code">{'<Button btnType="primary" btnSize="xlarge">xLarge</Button>'}</p>
         </div>
 
       </div>

--- a/demo/demoPages/components/ButtonPage.js
+++ b/demo/demoPages/components/ButtonPage.js
@@ -12,8 +12,8 @@ const ButtonPage = () => (
           <div className="code">
             <h3>Props:</h3>
             <ul>
-              <li>btnType:String === "primary", "cta", "default"</li>
-              <li>btnSize:String === "small", "large", "xlarge"</li>
+              <li>btnType:String === "primary", "cta", "default", "tertiary"</li>
+              <li>btnSize:String === "small", "large"</li>
               <li>btnIcon:Bool === true/false</li>
               <li>disabled</li>
             </ul>
@@ -22,6 +22,12 @@ const ButtonPage = () => (
           <h3>Icon Button:</h3>
           <Button btnIcon><Icon name="item-remove-24">close dialog</Icon></Button>
           <p className="code">{'<Button btnIcon><Icon name="item-remove-24">close dialog</Icon></Button>'}</p>
+
+          <br />
+
+          <h3>Tertiary Button:</h3>
+          <Button btnType="tertiary">Tertiary</Button>
+          <p className="code">{'<Button btnType="tertiary">Tertiary</Button>'}</p>
 
           <br />
 
@@ -50,12 +56,6 @@ const ButtonPage = () => (
 
           <br />
 
-          <h3>Primary Disabled Button:</h3>
-          <Button btnType="primary" disabled>Primary Disabled</Button>
-          <p className="code">{'<Button btnType="primary" disabled>Disabled</Button>'}</p>
-
-          <br />
-
           <h3>Small Button:</h3>
           <Button btnSize="small">Small</Button>
           <p className="code">{'<Button btnSize="small">Small</Button>'}</p>
@@ -67,16 +67,6 @@ const ButtonPage = () => (
           <p className="code">{'<Button btnSize="large">Large</Button>'}</p>
 
           <br />
-
-          <h3>XLarge Button:</h3>
-          <Button btnSize="xlarge">XLarge</Button>
-          <p className="code">{'<Button btnSize="xlarge">XLarge</Button>'}</p>
-
-          <br />
-
-          <h3>Primary XLarge Button:</h3>
-          <Button btnType="primary" btnSize="xlarge">Primary XLarge</Button>
-          <p className="code">{'<Button btnType="primary" btnSize="xlarge">XLarge</Button>'}</p>
         </div>
 
       </div>

--- a/demo/demoPages/styles/StylesButtonPage.js
+++ b/demo/demoPages/styles/StylesButtonPage.js
@@ -10,7 +10,9 @@ const StylesButtonPage = () => (
     are generally intended for content buttons rather than UI buttons. See below for <a href="#uibuttons">UI buttons</a>.</p>
       <button className="pe-btn__tertiary" style={marginFour}>Tertiary</button>
       <button className="pe-btn" style={marginFour}>Default</button>
+      {/* xlarge size is removed in button v3.0
       <button className="pe-btn__primary--btn_xlarge" style={marginFour}>Primary</button>
+      */}
       <button className="pe-btn__cta">Call To Action</button>
     <p className="code" style={{marginTop: 12, marginBottom: 16}}>
       {`<button class="pe-btn">Default</button>`} <br/>
@@ -23,7 +25,9 @@ const StylesButtonPage = () => (
     <p style={{marginBottom: 12}}>Button classes can be used with {`<div>`}, {`<span>`}, {`<a>`}, {`<button>`}, and {`<input>`} elements. But try very hard not to use button styles on divs, spans, or links.</p>
       <div className="pe-btn" tabindex="0" role="button" style={marginFour}>Div</div>
       <a href="#void" className="pe-btn" role="button" style={marginFour}>Link</a>
+      {/* xlarge size is removed in button v3.0
       <a href="#void" className="pe-btn__primary--btn_xlarge" role="button" style={marginFour}>Large Primary Link</a>
+      */}
       <button type="button" className="pe-btn" style={marginFour}>Button</button>
       <input className="pe-btn" type="submit" value="Submit" style={marginFour} />
       <button type="button" className="pe-link" style={marginFour}>Button</button>
@@ -63,8 +67,9 @@ const StylesButtonPage = () => (
     <p>Buttons can be made smaller or larger.</p>
     <button className="pe-btn--btn_small" style={marginFour}>Small</button>
     <button className="pe-btn__cta--btn_large" style={marginFour}>CTA Large</button>
+    {/* xlarge size is removed in button v3.0
     <button className="pe-btn__primary--btn_xlarge">Primary xLarge</button>
-
+    */}
     <p className="code" style={{padding: 8}}>
       {`<button class="pe-btn--btn_small" style={{marginRight: 3}}>Small</button>`} <br/>
       {`<button class="pe-btn__cta--btn_large">CTA Large</button>`} <br/>
@@ -118,7 +123,7 @@ const StylesButtonPage = () => (
         <use xlinkHref="#calendar-18"></use>
       </svg>
     </button>
-    <button type="button" className="pe-btn--btn_large pe-btn__cta" aria-label="End date" style={marginFour}>
+    <button type="button" className="pe-btn__cta--btn_large" aria-label="End date" style={marginFour}>
       CTA large with icon
       <svg aria-hidden="true"
            focusable="false"
@@ -126,6 +131,7 @@ const StylesButtonPage = () => (
         <use xlinkHref="#calendar-18"></use>
       </svg>
     </button>
+    {/* xlarge size is removed in button v3.0
     <button type="button" className="pe-btn__primary--btn_xlarge" aria-label="Start date">
       Primary xLarge with icon
       <svg aria-hidden="true"
@@ -134,6 +140,7 @@ const StylesButtonPage = () => (
         <use xlinkHref="#calendar-18"></use>
       </svg>
     </button>
+    */}
 
     <p>With size-24 icon:</p>
     <button type="button" className="pe-btn--btn_small" aria-label="End date" style={marginFour}>
@@ -144,7 +151,7 @@ const StylesButtonPage = () => (
         <use xlinkHref="#calendar-24"></use>
       </svg>
     </button>
-    <button type="button" className="pe-btn--btn_large pe-btn__cta" aria-label="Start date" style={marginFour}>
+    <button type="button" className="pe-btn__cta--btn_large" aria-label="Start date" style={marginFour}>
       CTA large with icon
       <svg aria-hidden="true"
            focusable="false"
@@ -152,6 +159,7 @@ const StylesButtonPage = () => (
         <use xlinkHref="#calendar-24"></use>
       </svg>
     </button>
+     {/* xlarge size is removed in button v3.0
     <button type="button" className="pe-btn__primary--btn_xlarge" aria-label="End date">
       Primary xLarge with icon
       <svg aria-hidden="true"
@@ -160,6 +168,7 @@ const StylesButtonPage = () => (
         <use xlinkHref="#calendar-24"></use>
       </svg>
     </button>
+    */}
 
     <p className="code">
       {`<button type="button" class="pe-btn--btn_small" aria-label="Start date">`} <br/>
@@ -170,7 +179,7 @@ const StylesButtonPage = () => (
       <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-18"></use>`} <br/></div>
       <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
       {`</button>`}
-      {`<button type="button" class="pe-btn--btn_large pe-btn__cta" aria-label="End date">`} <br/>
+      {`<button type="button" class="pe-btn__cta--btn_large" aria-label="End date">`} <br/>
       CTA large with icon
       <div style={{paddingLeft: 8}}>{`<svg aria-hidden="true"`} <br/></div>
       <div style={{paddingLeft: 36}}>{`focusable="false"`} <br/></div>
@@ -194,7 +203,7 @@ const StylesButtonPage = () => (
       <div style={{paddingLeft: 36}}>{`class="pe-icon--calendar-24">`} <br/></div>
       <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-24"></use>`} <br/></div>
       <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
-      {`</button>`}{`<button type="button" class="pe-btn--btn_large pe-btn__cta" aria-label="Start date">`} <br/>
+      {`</button>`}{`<button type="button" class="pe-btn__cta--btn_large" aria-label="Start date">`} <br/>
       CTA large with icon
       <div style={{paddingLeft: 8}}>{`<svg aria-hidden="true"`} <br/></div>
       <div style={{paddingLeft: 36}}>{`focusable="false"`} <br/></div>

--- a/demo/demoPages/styles/StylesButtonPage.js
+++ b/demo/demoPages/styles/StylesButtonPage.js
@@ -61,13 +61,13 @@ const StylesButtonPage = () => (
 
     <h2>Sizes</h2>
 
-    <p>Buttons can be made smaller or larger.</p>
+    <p>Buttons can be made smaller or larger. Large is the standard button size, prefer this button as a default size unless there is a reason to go up or down.</p>
     <button className="pe-btn--btn_small" style={marginFour}>Small</button>
-    <button className="pe-btn__cta--btn_large" style={marginFour}>CTA Large</button>
+    <button className="pe-btn__cta" style={marginFour}>CTA Large</button>
     <button className="pe-btn__primary--btn_xlarge" style={marginFour}>Primary xLarge</button>
     <p className="code" style={{padding: 8}}>
       {`<button class="pe-btn--btn_small">Small</button>`} <br/>
-      {`<button class="pe-btn__cta--btn_large">CTA Large</button>`} <br/>
+      {`<button class="pe-btn__cta">CTA Large</button>`} <br/>
       {`<button class="pe-btn__primary--btn_xlarge">Primary xLarge</button>`}
     </p>
 
@@ -118,7 +118,7 @@ const StylesButtonPage = () => (
         <use xlinkHref="#calendar-18"></use>
       </svg>
     </button>
-    <button type="button" className="pe-btn__cta--btn_large" aria-label="End date" style={marginFour}>
+    <button type="button" className="pe-btn__cta" aria-label="End date" style={marginFour}>
       CTA large with icon
       <svg aria-hidden="true"
            focusable="false"
@@ -144,7 +144,7 @@ const StylesButtonPage = () => (
         <use xlinkHref="#calendar-24"></use>
       </svg>
     </button>
-    <button type="button" className="pe-btn__cta--btn_large" aria-label="Start date" style={marginFour}>
+    <button type="button" className="pe-btn__cta" aria-label="Start date" style={marginFour}>
       CTA large with icon
       <svg aria-hidden="true"
            focusable="false"
@@ -170,7 +170,7 @@ const StylesButtonPage = () => (
       <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-18"></use>`} <br/></div>
       <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
       {`</button>`}<br/>
-      {`<button type="button" class="pe-btn__cta--btn_large" aria-label="End date">`} <br/>
+      {`<button type="button" class="pe-btn__cta" aria-label="End date">`} <br/>
       CTA large with icon
       <div style={{paddingLeft: 8}}>{`<svg aria-hidden="true"`} <br/></div>
       <div style={{paddingLeft: 36}}>{`focusable="false"`} <br/></div>
@@ -194,7 +194,7 @@ const StylesButtonPage = () => (
       <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-24"></use>`} <br/></div>
       <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
       {`</button>`}<br/>
-      {`<button type="button" class="pe-btn__cta--btn_large" aria-label="Start date">`} <br/>
+      {`<button type="button" class="pe-btn__cta" aria-label="Start date">`} <br/>
       CTA large with icon
       <div style={{paddingLeft: 8}}>{`<svg aria-hidden="true"`} <br/></div>
       <div style={{paddingLeft: 36}}>{`focusable="false"`} <br/></div>

--- a/demo/demoPages/styles/StylesButtonPage.js
+++ b/demo/demoPages/styles/StylesButtonPage.js
@@ -66,9 +66,9 @@ const StylesButtonPage = () => (
     <button className="pe-btn__cta--btn_large" style={marginFour}>CTA Large</button>
     <button className="pe-btn__primary--btn_xlarge" style={marginFour}>Primary xLarge</button>
     <p className="code" style={{padding: 8}}>
-      {`<button class="pe-btn--btn_small" style={{marginRight: 3}}>Small</button>`} <br/>
+      {`<button class="pe-btn--btn_small">Small</button>`} <br/>
       {`<button class="pe-btn__cta--btn_large">CTA Large</button>`} <br/>
-      {`<button class="pe-btn__primary--btn_xlarge" style={marginFour}>Primary xLarge</button>`}
+      {`<button class="pe-btn__primary--btn_xlarge">Primary xLarge</button>`}
     </p>
 
     <h2>Text overflow</h2>

--- a/demo/demoPages/styles/StylesButtonPage.js
+++ b/demo/demoPages/styles/StylesButtonPage.js
@@ -10,14 +10,13 @@ const StylesButtonPage = () => (
     are generally intended for content buttons rather than UI buttons. See below for <a href="#uibuttons">UI buttons</a>.</p>
       <button className="pe-btn__tertiary" style={marginFour}>Tertiary</button>
       <button className="pe-btn" style={marginFour}>Default</button>
-      {/* xlarge size is removed in button v3.0
-      <button className="pe-btn__primary--btn_xlarge" style={marginFour}>Primary</button>
-      */}
-      <button className="pe-btn__cta">Call To Action</button>
+      <button className="pe-btn__cta" style={marginFour}>Call To Action</button>
+      <button className="pe-btn__primary">Primary</button>
     <p className="code" style={{marginTop: 12, marginBottom: 16}}>
+      {`<button class="pe-btn__tertiary">Tertiary</button>`} <br/>
       {`<button class="pe-btn">Default</button>`} <br/>
-      {`<button class="pe-btn__primary--btn_xlarge">Primary</button>`} <br/>
-      {`<button class="pe-btn__cta">Call To Action</button>`}
+      {`<button class="pe-btn__cta">Call To Action</button>`} <br/>
+      {`<button className="pe-btn__primary">Primary</button>`}
     </p>
 
     <h2>Elements</h2>
@@ -25,9 +24,7 @@ const StylesButtonPage = () => (
     <p style={{marginBottom: 12}}>Button classes can be used with {`<div>`}, {`<span>`}, {`<a>`}, {`<button>`}, and {`<input>`} elements. But try very hard not to use button styles on divs, spans, or links.</p>
       <div className="pe-btn" tabindex="0" role="button" style={marginFour}>Div</div>
       <a href="#void" className="pe-btn" role="button" style={marginFour}>Link</a>
-      {/* xlarge size is removed in button v3.0
-      <a href="#void" className="pe-btn__primary--btn_xlarge" role="button" style={marginFour}>Large Primary Link</a>
-      */}
+      <a href="#void" className="pe-btn__primary--btn_large" role="button" style={marginFour}>Large Primary Link</a>
       <button type="button" className="pe-btn" style={marginFour}>Button</button>
       <input className="pe-btn" type="submit" value="Submit" style={marginFour} />
       <button type="button" className="pe-link" style={marginFour}>Button</button>
@@ -36,7 +33,7 @@ const StylesButtonPage = () => (
     <p className="code">
       {`<div class="pe-btn" tabindex="0" role="button">Div</div>`} <br/>
       {`<a href="#void" class="pe-btn" role="button">Link</a>`} <br/>
-      {`<a href="#void" class="pe-btn__primary--btn_xlarge" role="button">Large Primary Link</a>`} <br/>
+      {`<a href="#void" class="pe-btn__primary--btn_large" role="button">Large Primary Link</a>`} <br/>
       {`<button type="button" class="pe-btn">Button</button>`} <br/>
       {`<input class="pe-btn" type="submit" value="Submit" />`} <br/>
       {`<button type="button" class="pe-link">Button</button>`} <br/>
@@ -67,13 +64,9 @@ const StylesButtonPage = () => (
     <p>Buttons can be made smaller or larger.</p>
     <button className="pe-btn--btn_small" style={marginFour}>Small</button>
     <button className="pe-btn__cta--btn_large" style={marginFour}>CTA Large</button>
-    {/* xlarge size is removed in button v3.0
-    <button className="pe-btn__primary--btn_xlarge">Primary xLarge</button>
-    */}
     <p className="code" style={{padding: 8}}>
       {`<button class="pe-btn--btn_small" style={{marginRight: 3}}>Small</button>`} <br/>
       {`<button class="pe-btn__cta--btn_large">CTA Large</button>`} <br/>
-      {`<button class="pe-btn__primary--btn_xlarge" style={{marginLeft: 3}}>Primary xLarge</button>`}
     </p>
 
     <h2>Text overflow</h2>
@@ -131,16 +124,6 @@ const StylesButtonPage = () => (
         <use xlinkHref="#calendar-18"></use>
       </svg>
     </button>
-    {/* xlarge size is removed in button v3.0
-    <button type="button" className="pe-btn__primary--btn_xlarge" aria-label="Start date">
-      Primary xLarge with icon
-      <svg aria-hidden="true"
-           focusable="false"
-           className="pe-icon--calendar-18">
-        <use xlinkHref="#calendar-18"></use>
-      </svg>
-    </button>
-    */}
 
     <p>With size-24 icon:</p>
     <button type="button" className="pe-btn--btn_small" aria-label="End date" style={marginFour}>
@@ -159,16 +142,6 @@ const StylesButtonPage = () => (
         <use xlinkHref="#calendar-24"></use>
       </svg>
     </button>
-     {/* xlarge size is removed in button v3.0
-    <button type="button" className="pe-btn__primary--btn_xlarge" aria-label="End date">
-      Primary xLarge with icon
-      <svg aria-hidden="true"
-           focusable="false"
-           className="pe-icon--calendar-24">
-        <use xlinkHref="#calendar-24"></use>
-      </svg>
-    </button>
-    */}
 
     <p className="code">
       {`<button type="button" class="pe-btn--btn_small" aria-label="Start date">`} <br/>
@@ -181,14 +154,6 @@ const StylesButtonPage = () => (
       {`</button>`}
       {`<button type="button" class="pe-btn__cta--btn_large" aria-label="End date">`} <br/>
       CTA large with icon
-      <div style={{paddingLeft: 8}}>{`<svg aria-hidden="true"`} <br/></div>
-      <div style={{paddingLeft: 36}}>{`focusable="false"`} <br/></div>
-      <div style={{paddingLeft: 36}}>{`class="pe-icon--calendar-18">`} <br/></div>
-      <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-18"></use>`} <br/></div>
-      <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
-      {`</button>`}
-      {`<button type="button" class="pe-btn__primary--btn_xlarge" aria-label="Start date">`} <br/>
-      Primary xLarge with icon
       <div style={{paddingLeft: 8}}>{`<svg aria-hidden="true"`} <br/></div>
       <div style={{paddingLeft: 36}}>{`focusable="false"`} <br/></div>
       <div style={{paddingLeft: 36}}>{`class="pe-icon--calendar-18">`} <br/></div>
@@ -211,13 +176,6 @@ const StylesButtonPage = () => (
       <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-24"></use>`} <br/></div>
       <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
       {`</button>`}{`<button type="button" class="pe-btn__primary--btn_xlarge" aria-label="End date">`} <br/>
-      Primary xLarge with icon
-      <div style={{paddingLeft: 8}}>{`<svg aria-hidden="true"`} <br/></div>
-      <div style={{paddingLeft: 36}}>{`focusable="false"`} <br/></div>
-      <div style={{paddingLeft: 36}}>{`class="pe-icon--calendar-24">`} <br/></div>
-      <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-24"></use>`} <br/></div>
-      <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
-      {`</button>`}
     </p>
 
   </div>

--- a/demo/demoPages/styles/StylesButtonPage.js
+++ b/demo/demoPages/styles/StylesButtonPage.js
@@ -24,7 +24,7 @@ const StylesButtonPage = () => (
     <p style={{marginBottom: 12}}>Button classes can be used with {`<div>`}, {`<span>`}, {`<a>`}, {`<button>`}, and {`<input>`} elements. But try very hard not to use button styles on divs, spans, or links.</p>
       <div className="pe-btn" tabindex="0" role="button" style={marginFour}>Div</div>
       <a href="#void" className="pe-btn" role="button" style={marginFour}>Link</a>
-      <a href="#void" className="pe-btn__primary--btn_large" role="button" style={marginFour}>Large Primary Link</a>
+      <a href="#void" className="pe-btn__primary--btn_xlarge" role="button" style={marginFour}>xLarge Primary Link</a>
       <button type="button" className="pe-btn" style={marginFour}>Button</button>
       <input className="pe-btn" type="submit" value="Submit" style={marginFour} />
       <button type="button" className="pe-link" style={marginFour}>Button</button>
@@ -33,7 +33,7 @@ const StylesButtonPage = () => (
     <p className="code">
       {`<div class="pe-btn" tabindex="0" role="button">Div</div>`} <br/>
       {`<a href="#void" class="pe-btn" role="button">Link</a>`} <br/>
-      {`<a href="#void" class="pe-btn__primary--btn_large" role="button">Large Primary Link</a>`} <br/>
+      {`<a href="#void" class="pe-btn__primary--btn_xlarge" role="button">xLarge Primary Link</a>`} <br/>
       {`<button type="button" class="pe-btn">Button</button>`} <br/>
       {`<input class="pe-btn" type="submit" value="Submit" />`} <br/>
       {`<button type="button" class="pe-link">Button</button>`} <br/>
@@ -64,9 +64,11 @@ const StylesButtonPage = () => (
     <p>Buttons can be made smaller or larger.</p>
     <button className="pe-btn--btn_small" style={marginFour}>Small</button>
     <button className="pe-btn__cta--btn_large" style={marginFour}>CTA Large</button>
+    <button className="pe-btn__primary--btn_xlarge" style={marginFour}>Primary xLarge</button>
     <p className="code" style={{padding: 8}}>
       {`<button class="pe-btn--btn_small" style={{marginRight: 3}}>Small</button>`} <br/>
       {`<button class="pe-btn__cta--btn_large">CTA Large</button>`} <br/>
+      {`<button className="pe-btn__primary--btn_xlarge" style={marginFour}>Primary xLarge</button>`}
     </p>
 
     <h2>Text overflow</h2>
@@ -124,6 +126,14 @@ const StylesButtonPage = () => (
         <use xlinkHref="#calendar-18"></use>
       </svg>
     </button>
+    <button type="button" className="pe-btn__primary--btn_xlarge" aria-label="End date" style={marginFour}>
+      Primary xLarge with icon
+      <svg aria-hidden="true"
+           focusable="false"
+           className="pe-icon--calendar-18">
+        <use xlinkHref="#calendar-18"></use>
+      </svg>
+    </button>
 
     <p>With size-24 icon:</p>
     <button type="button" className="pe-btn--btn_small" aria-label="End date" style={marginFour}>
@@ -142,6 +152,14 @@ const StylesButtonPage = () => (
         <use xlinkHref="#calendar-24"></use>
       </svg>
     </button>
+    <button type="button" className="pe-btn__primary--btn_xlarge" aria-label="Start date" style={marginFour}>
+      Primary xLarge with icon
+      <svg aria-hidden="true"
+           focusable="false"
+           className="pe-icon--calendar-24">
+        <use xlinkHref="#calendar-24"></use>
+      </svg>
+    </button>
 
     <p className="code">
       {`<button type="button" class="pe-btn--btn_small" aria-label="Start date">`} <br/>
@@ -151,7 +169,7 @@ const StylesButtonPage = () => (
       <div style={{paddingLeft: 36}}>{`class="pe-icon--calendar-18">`} <br/></div>
       <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-18"></use>`} <br/></div>
       <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
-      {`</button>`}
+      {`</button>`}<br/>
       {`<button type="button" class="pe-btn__cta--btn_large" aria-label="End date">`} <br/>
       CTA large with icon
       <div style={{paddingLeft: 8}}>{`<svg aria-hidden="true"`} <br/></div>
@@ -159,8 +177,15 @@ const StylesButtonPage = () => (
       <div style={{paddingLeft: 36}}>{`class="pe-icon--calendar-18">`} <br/></div>
       <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-18"></use>`} <br/></div>
       <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
-      {`</button>`}
-      <br/>
+      {`</button>`}<br/>
+      {`<button type="button" class="pe-btn__primary--btn_xlarge" aria-label="End date">`} <br/>
+      Primary xLarge with icon
+      <div style={{paddingLeft: 8}}>{`<svg aria-hidden="true"`} <br/></div>
+      <div style={{paddingLeft: 36}}>{`focusable="false"`} <br/></div>
+      <div style={{paddingLeft: 36}}>{`class="pe-icon--calendar-18">`} <br/></div>
+      <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-18"></use>`} <br/></div>
+      <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
+      {`</button>`}<br/>
       {`<button type="button" class="pe-btn--btn_small" aria-label="End date">`} <br/>
       Small with icon
       <div style={{paddingLeft: 8}}>{`<svg aria-hidden="true"`} <br/></div>
@@ -168,14 +193,23 @@ const StylesButtonPage = () => (
       <div style={{paddingLeft: 36}}>{`class="pe-icon--calendar-24">`} <br/></div>
       <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-24"></use>`} <br/></div>
       <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
-      {`</button>`}{`<button type="button" class="pe-btn__cta--btn_large" aria-label="Start date">`} <br/>
+      {`</button>`}<br/>
+      {`<button type="button" class="pe-btn__cta--btn_large" aria-label="Start date">`} <br/>
       CTA large with icon
       <div style={{paddingLeft: 8}}>{`<svg aria-hidden="true"`} <br/></div>
       <div style={{paddingLeft: 36}}>{`focusable="false"`} <br/></div>
       <div style={{paddingLeft: 36}}>{`class="pe-icon--calendar-24">`} <br/></div>
       <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-24"></use>`} <br/></div>
       <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
-      {`</button>`}{`<button type="button" class="pe-btn__primary--btn_xlarge" aria-label="End date">`} <br/>
+      {`</button>`}<br/>
+      {`<button type="button" class="pe-btn__primary--btn_xlarge" aria-label="End date">`} <br/>
+      Primary xLarge with icon
+      <div style={{paddingLeft: 8}}>{`<svg aria-hidden="true"`} <br/></div>
+      <div style={{paddingLeft: 36}}>{`focusable="false"`} <br/></div>
+      <div style={{paddingLeft: 36}}>{`class="pe-icon--calendar-24">`} <br/></div>
+      <div style={{paddingLeft: 16}}>{`<use xlink:href="#calendar-24"></use>`} <br/></div>
+      <div style={{paddingLeft: 8}}>{`</svg>`} <br/></div>
+      {`</button>`}
     </p>
 
   </div>

--- a/demo/demoPages/styles/StylesButtonPage.js
+++ b/demo/demoPages/styles/StylesButtonPage.js
@@ -8,6 +8,7 @@ const StylesButtonPage = () => (
 
     <p>Use a button to represent a user action&#8212; specifically, pressing it should perform an action on a page or document, rather than navigating a user elsewhere. These button styles
     are generally intended for content buttons rather than UI buttons. See below for <a href="#uibuttons">UI buttons</a>.</p>
+      <button className="pe-btn__tertiary" style={marginFour}>Tertiary</button>
       <button className="pe-btn" style={marginFour}>Default</button>
       <button className="pe-btn__primary--btn_xlarge" style={marginFour}>Primary</button>
       <button className="pe-btn__cta">Call To Action</button>

--- a/demo/demoPages/styles/StylesButtonPage.js
+++ b/demo/demoPages/styles/StylesButtonPage.js
@@ -16,7 +16,7 @@ const StylesButtonPage = () => (
       {`<button class="pe-btn__tertiary">Tertiary</button>`} <br/>
       {`<button class="pe-btn">Default</button>`} <br/>
       {`<button class="pe-btn__cta">Call To Action</button>`} <br/>
-      {`<button className="pe-btn__primary">Primary</button>`}
+      {`<button class="pe-btn__primary">Primary</button>`}
     </p>
 
     <h2>Elements</h2>
@@ -57,7 +57,7 @@ const StylesButtonPage = () => (
 
     <p>For elements that do not support the `disabled` attribute, use `pe-btn--disabled` and `aria-disabled`.</p>
     <div className="pe-btn pe-btn--disabled" aria-disabled="true">Not a button</div> <br/><br/>
-    <p className="code">{`<div className="pe-btn pe-btn--disabled" aria-disabled="true">Not a button</div>`}</p>
+    <p className="code">{`<div class="pe-btn pe-btn--disabled" aria-disabled="true">Not a button</div>`}</p>
 
     <h2>Sizes</h2>
 
@@ -68,7 +68,7 @@ const StylesButtonPage = () => (
     <p className="code" style={{padding: 8}}>
       {`<button class="pe-btn--btn_small" style={{marginRight: 3}}>Small</button>`} <br/>
       {`<button class="pe-btn__cta--btn_large">CTA Large</button>`} <br/>
-      {`<button className="pe-btn__primary--btn_xlarge" style={marginFour}>Primary xLarge</button>`}
+      {`<button class="pe-btn__primary--btn_xlarge" style={marginFour}>Primary xLarge</button>`}
     </p>
 
     <h2>Text overflow</h2>
@@ -96,7 +96,7 @@ const StylesButtonPage = () => (
     </button>
 
     <p className="code">
-      {`<button type="button" className="pe-icon--btn">`}
+      {`<button type="button" class="pe-icon--btn">`}
       <div style={{paddingLeft: 8}}>{`<svg role="img"`} <br/></div>
       <div style={{paddingLeft: 36}}>{`aria-labelledby="b1"`} <br/></div>
       <div style={{paddingLeft: 36}}>{`focusable="false"`} <br/></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pearson-components/elements-sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9094,11 +9094,6 @@
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
       "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
       "dev": true
-    },
-    "moment": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.0.tgz",
-      "integrity": "sha1-RPZ172uUSUJ2JYGxwXn7Z55ZnWc="
     },
     "mozjpeg": {
       "version": "4.1.1",

--- a/src/styles/elements/buttons/_buttons.scss
+++ b/src/styles/elements/buttons/_buttons.scss
@@ -1,44 +1,47 @@
 @import 'variables';
 @import 'mixins';
 
-
 %btn {
   box-sizing     : border-box;
-  border-radius  : $pe-btn-border-radius;
   border         : none;
   display        : inline-block;
   vertical-align : middle;
   cursor         : pointer;
-  font-size      : $pe-btn-small-font-size;
-  height         : $pe-btn-small-height;
-  line-height    : $pe-btn-small-height;
-  padding        : $pe-btn-small-padding;
+
+  // Large: The standard button size, prefer this button as a default size 
+  // unless there is a reason to go up or down.
+  height         : $pe-btn-large-height;
+  padding        : $pe-btn-large-padding;
+  border-radius  : $pe-btn-large-border-radius;
+  font-size      : $pe-btn-large-font-size;
+  line-height    : $pe-btn-large-height;
+
   font-weight    : 600;
-  margin-bottom  : .5em;
+
   svg {
     margin-left  : .5em;
-    margin-bottom  : .5em;
+    //margin-bottom  : .5em;
     vertical-align : middle;
     }
 
 }
 
 %btn_large {
-  height      : $pe-btn-large-height;
-  font-size   : $pe-btn-large-font-size;
-  line-height : $pe-btn-large-height;
-  padding     : $pe-btn-large-padding;
+  height         : $pe-btn-large-height;
+  border-radius  : $pe-btn-large-border-radius;
+  padding        : $pe-btn-large-padding;
+  font-size      : $pe-btn-large-font-size;
+  line-height    : $pe-btn-large-height;
 }
 
-// xlarge size is removed in button v3.0
 %btn_xlarge {
-  height      : $pe-btn-xlarge-height;
-  font-size   : $pe-btn-xlarge-font-size;
-  line-height : $pe-btn-xlarge-height;
-  padding     : $pe-btn-xlarge-padding;
+  height         : $pe-btn-xlarge-height;
+  border-radius  : $pe-btn-xlarge-border-radius;
+  padding        : $pe-btn-xlarge-padding;
+  font-size      : $pe-btn-xlarge-font-size;
+  line-height    : $pe-btn-xlarge-height; 
 }
 
-// For icons in buttons, remove buttony styles
 
 .pe-icon--btn {
   padding: 0;
@@ -87,13 +90,13 @@
 .pe-btn {
 
   @extend %btn;
-  border: $pe-btn-default-border;
 
   @include pe-btn(
     $pe-btn-default-bg,
     $pe-btn-default-text,
     $pe-btn-default-hover-bg,
     $pe-btn-default-hover-text,
+    $pe-btn-default-border,
     $pe-btn-default-hover-border,
     $pe-btn-default-disabled-bg,
     $pe-btn-default-disabled-text
@@ -120,13 +123,13 @@
 .pe-btn--btn_small {
 
   @extend %btn;
-  border: $pe-btn-default-border;
 
   @include pe-btn(
     $pe-btn-default-bg,
     $pe-btn-default-text,
     $pe-btn-default-hover-bg,
     $pe-btn-default-hover-text,
+    $pe-btn-default-border,
     $pe-btn-default-hover-border,
     $pe-btn-default-disabled-bg,
     $pe-btn-default-disabled-text
@@ -138,13 +141,13 @@
 
   @extend %btn;
   @extend %btn_large;
-  border: $pe-btn-default-border;
 
   @include pe-btn(
     $pe-btn-default-bg,
     $pe-btn-default-text,
     $pe-btn-default-hover-bg,
     $pe-btn-default-hover-text,
+    $pe-btn-default-border,
     $pe-btn-default-hover-border,
     $pe-btn-default-disabled-bg,
     $pe-btn-default-disabled-text
@@ -152,18 +155,18 @@
 
 }
 
-// xlarge size is removed in button v3.0
 .pe-btn--btn_xlarge {
 
   @extend %btn;
   @extend %btn_xlarge;
-  border: $pe-btn-default-border;
 
   @include pe-btn(
     $pe-btn-default-bg,
     $pe-btn-default-text,
     $pe-btn-default-hover-bg,
     $pe-btn-default-hover-text,
+    $pe-btn-default-border,
+    $pe-btn-default-hover-border,
     $pe-btn-default-disabled-bg,
     $pe-btn-default-disabled-text
   );
@@ -208,7 +211,6 @@
   );
 }
 
-// xlarge size is removed in button v3.0
 .pe-btn__primary--btn_xlarge {
 
   @extend %btn;
@@ -262,7 +264,6 @@
   );
 }
 
-// xlarge size is removed in button v3.0
 .pe-btn__cta--btn_xlarge {
 
   @extend %btn;
@@ -313,7 +314,7 @@
       $pe-btn-tertiary-hover-text
     );
   }
-  // xlarge size is removed in button v3.0
+ 
   .pe-btn__tertiary--btn_xlarge {
   
     @extend %btn;

--- a/src/styles/elements/buttons/_buttons.scss
+++ b/src/styles/elements/buttons/_buttons.scss
@@ -3,6 +3,7 @@
 
 
 %btn {
+  box-sizing     : border-box;
   border-radius  : $pe-btn-border-radius;
   border         : none;
   display        : inline-block;
@@ -13,6 +14,13 @@
   line-height    : $pe-btn-small-height;
   padding        : $pe-btn-small-padding;
   font-weight    : 600;
+  margin-bottom  : .5em;
+  svg {
+    margin-left  : .5em;
+    margin-bottom  : .5em;
+    vertical-align : middle;
+    }
+
 }
 
 %btn_large {
@@ -21,14 +29,14 @@
   line-height : $pe-btn-large-height;
   padding     : $pe-btn-large-padding;
 }
-/* xlarge size is removed in button v3.0
+
+// xlarge size is removed in button v3.0
 %btn_xlarge {
   height      : $pe-btn-xlarge-height;
   font-size   : $pe-btn-xlarge-font-size;
   line-height : $pe-btn-xlarge-height;
   padding     : $pe-btn-xlarge-padding;
 }
-*/
 
 // For icons in buttons, remove buttony styles
 
@@ -86,6 +94,7 @@
     $pe-btn-default-text,
     $pe-btn-default-hover-bg,
     $pe-btn-default-hover-text,
+    $pe-btn-default-hover-border,
     $pe-btn-default-disabled-bg,
     $pe-btn-default-disabled-text
   );
@@ -118,6 +127,7 @@
     $pe-btn-default-text,
     $pe-btn-default-hover-bg,
     $pe-btn-default-hover-text,
+    $pe-btn-default-hover-border,
     $pe-btn-default-disabled-bg,
     $pe-btn-default-disabled-text
   );
@@ -135,13 +145,14 @@
     $pe-btn-default-text,
     $pe-btn-default-hover-bg,
     $pe-btn-default-hover-text,
+    $pe-btn-default-hover-border,
     $pe-btn-default-disabled-bg,
     $pe-btn-default-disabled-text
   );
 
 }
 
-/* xlarge size is removed in button v3.0
+// xlarge size is removed in button v3.0
 .pe-btn--btn_xlarge {
 
   @extend %btn;
@@ -158,7 +169,6 @@
   );
 
 }
-*/
 
 //===========Primary=================================
 .pe-btn__primary {
@@ -198,7 +208,7 @@
   );
 }
 
-/* xlarge size is removed in button v3.0
+// xlarge size is removed in button v3.0
 .pe-btn__primary--btn_xlarge {
 
   @extend %btn;
@@ -211,7 +221,7 @@
   $pe-color-white
   );
 }
-*/
+
 
 
 //===========CTA=================================
@@ -252,7 +262,7 @@
   );
 }
 
-/* xlarge size is removed in button v3.0
+// xlarge size is removed in button v3.0
 .pe-btn__cta--btn_xlarge {
 
   @extend %btn;
@@ -265,7 +275,7 @@
     $pe-btn-cta-hover-text
   );
 }
-*/
+
 //===========TERTIARY=================================
 .pe-btn__tertiary {
   
@@ -303,7 +313,7 @@
       $pe-btn-tertiary-hover-text
     );
   }
-  /* xlarge size is removed in button v3.0
+  // xlarge size is removed in button v3.0
   .pe-btn__tertiary--btn_xlarge {
   
     @extend %btn;
@@ -316,4 +326,34 @@
       $pe-btn-tertiary-hover-text
     );
   }
-  */ 
+  
+
+
+  /*
+.pe-btn--btn_small{
+  .pe-icon--calendar-18{
+    padding-left: 10px;
+  }
+}
+
+.pe-btn__cta--btn_large{
+  .pe-icon--calendar-18{
+    padding-top: 2px;
+    padding-left: 10px;
+  }
+}
+
+.pe-btn--btn_small{
+  .pe-icon--calendar-24{
+    padding-top: 4px;
+    padding-left: 10px;
+  }
+}
+
+.pe-btn__cta--btn_large{
+  .pe-icon--calendar-24{
+    padding-top: 8px;
+    padding-left: 10px;
+  }
+}
+*/

--- a/src/styles/elements/buttons/_buttons.scss
+++ b/src/styles/elements/buttons/_buttons.scss
@@ -21,13 +21,14 @@
   line-height : $pe-btn-large-height;
   padding     : $pe-btn-large-padding;
 }
-
+/* xlarge size is removed in button v3.0
 %btn_xlarge {
   height      : $pe-btn-xlarge-height;
   font-size   : $pe-btn-xlarge-font-size;
   line-height : $pe-btn-xlarge-height;
   padding     : $pe-btn-xlarge-padding;
 }
+*/
 
 // For icons in buttons, remove buttony styles
 
@@ -140,6 +141,7 @@
 
 }
 
+/* xlarge size is removed in button v3.0
 .pe-btn--btn_xlarge {
 
   @extend %btn;
@@ -156,6 +158,7 @@
   );
 
 }
+*/
 
 //===========Primary=================================
 .pe-btn__primary {
@@ -195,6 +198,7 @@
   );
 }
 
+/* xlarge size is removed in button v3.0
 .pe-btn__primary--btn_xlarge {
 
   @extend %btn;
@@ -207,6 +211,7 @@
   $pe-color-white
   );
 }
+*/
 
 
 //===========CTA=================================
@@ -247,6 +252,7 @@
   );
 }
 
+/* xlarge size is removed in button v3.0
 .pe-btn__cta--btn_xlarge {
 
   @extend %btn;
@@ -259,7 +265,7 @@
     $pe-btn-cta-hover-text
   );
 }
-
+*/
 //===========TERTIARY=================================
 .pe-btn__tertiary {
   
@@ -297,7 +303,7 @@
       $pe-btn-tertiary-hover-text
     );
   }
-  
+  /* xlarge size is removed in button v3.0
   .pe-btn__tertiary--btn_xlarge {
   
     @extend %btn;
@@ -310,3 +316,4 @@
       $pe-btn-tertiary-hover-text
     );
   }
+  */ 

--- a/src/styles/elements/buttons/_buttons.scss
+++ b/src/styles/elements/buttons/_buttons.scss
@@ -17,29 +17,23 @@
   line-height    : $pe-btn-large-height;
 
   font-weight    : 600;
-
-  svg {
-    margin-left  : .5em;
-    //margin-bottom  : .5em;
-    vertical-align : middle;
-    }
-
 }
 
-%btn_large {
-  height         : $pe-btn-large-height;
-  border-radius  : $pe-btn-large-border-radius;
-  padding        : $pe-btn-large-padding;
-  font-size      : $pe-btn-large-font-size;
-  line-height    : $pe-btn-large-height;
+%btn_small {
+  height         : $pe-btn-small-height;
+  border-radius  : $pe-btn-small-border-radius;
+  padding        : $pe-btn-small-padding;
+  font-size      : $pe-btn-small-font-size;
+  line-height    : $pe-btn-small-line-height;
 }
+
 
 %btn_xlarge {
   height         : $pe-btn-xlarge-height;
   border-radius  : $pe-btn-xlarge-border-radius;
   padding        : $pe-btn-xlarge-padding;
   font-size      : $pe-btn-xlarge-font-size;
-  line-height    : $pe-btn-xlarge-height; 
+  line-height    : $pe-btn-xlarge-line-height; 
 }
 
 
@@ -123,6 +117,7 @@
 .pe-btn--btn_small {
 
   @extend %btn;
+  @extend %btn_small;
 
   @include pe-btn(
     $pe-btn-default-bg,
@@ -140,7 +135,6 @@
 .pe-btn--btn_large {
 
   @extend %btn;
-  @extend %btn_large;
 
   @include pe-btn(
     $pe-btn-default-bg,
@@ -201,7 +195,6 @@
 .pe-btn__primary--btn_large {
 
   @extend %btn;
-  @extend %btn_large;
 
   @include pe-btn(
   $pe-color-digital-pearson-blue,
@@ -254,7 +247,6 @@
 .pe-btn__cta--btn_large {
 
   @extend %btn;
-  @extend %btn_large;
 
   @include pe-btn(
     $pe-btn-cta-bg,
@@ -305,7 +297,6 @@
   .pe-btn__tertiary--btn_large {
   
     @extend %btn;
-    @extend %btn_large;
   
     @include pe-btn(
       $pe-btn-tertiary-bg,
@@ -328,33 +319,3 @@
     );
   }
   
-
-
-  /*
-.pe-btn--btn_small{
-  .pe-icon--calendar-18{
-    padding-left: 10px;
-  }
-}
-
-.pe-btn__cta--btn_large{
-  .pe-icon--calendar-18{
-    padding-top: 2px;
-    padding-left: 10px;
-  }
-}
-
-.pe-btn--btn_small{
-  .pe-icon--calendar-24{
-    padding-top: 4px;
-    padding-left: 10px;
-  }
-}
-
-.pe-btn__cta--btn_large{
-  .pe-icon--calendar-24{
-    padding-top: 8px;
-    padding-left: 10px;
-  }
-}
-*/

--- a/src/styles/elements/buttons/_buttons.scss
+++ b/src/styles/elements/buttons/_buttons.scss
@@ -14,7 +14,7 @@
   padding        : $pe-btn-large-padding;
   border-radius  : $pe-btn-large-border-radius;
   font-size      : $pe-btn-large-font-size;
-  line-height    : $pe-btn-large-height;
+  line-height    : $pe-btn-large-line-height;
 
   font-weight    : 600;
 }
@@ -81,7 +81,7 @@
 }
 
 //===========btn=================================
-.pe-btn {
+.pe-btn, .pe-btn--btn_large {
 
   @extend %btn;
 
@@ -132,23 +132,6 @@
 
 }
 
-.pe-btn--btn_large {
-
-  @extend %btn;
-
-  @include pe-btn(
-    $pe-btn-default-bg,
-    $pe-btn-default-text,
-    $pe-btn-default-hover-bg,
-    $pe-btn-default-hover-text,
-    $pe-btn-default-border,
-    $pe-btn-default-hover-border,
-    $pe-btn-default-disabled-bg,
-    $pe-btn-default-disabled-text
-  );
-
-}
-
 .pe-btn--btn_xlarge {
 
   @extend %btn;
@@ -168,7 +151,7 @@
 }
 
 //===========Primary=================================
-.pe-btn__primary {
+.pe-btn__primary, .pe-btn__primary--btn_large {
 
   @extend %btn;
 
@@ -183,18 +166,7 @@
 .pe-btn__primary--btn_small {
 
   @extend %btn;
-
-  @include pe-btn(
-  $pe-color-digital-pearson-blue,
-  $pe-color-white,
-  $pe-color-ink-blue,
-  $pe-color-white
-  );
-}
-
-.pe-btn__primary--btn_large {
-
-  @extend %btn;
+  @extend %btn_small;
 
   @include pe-btn(
   $pe-color-digital-pearson-blue,
@@ -220,7 +192,7 @@
 
 
 //===========CTA=================================
-.pe-btn__cta {
+.pe-btn__cta, .pe-btn__cta--btn_large {
 
   @extend %btn;
 
@@ -235,18 +207,7 @@
 .pe-btn__cta--btn_small {
 
   @extend %btn;
-
-  @include pe-btn(
-    $pe-btn-cta-bg,
-    $pe-btn-cta-text,
-    $pe-btn-cta-hover-bg,
-    $pe-btn-cta-hover-text
-  );
-}
-
-.pe-btn__cta--btn_large {
-
-  @extend %btn;
+  @extend %btn_small;
 
   @include pe-btn(
     $pe-btn-cta-bg,
@@ -270,7 +231,7 @@
 }
 
 //===========TERTIARY=================================
-.pe-btn__tertiary {
+.pe-btn__tertiary, .pe-btn__tertiary--btn_large {
   
     @extend %btn;
   
@@ -285,18 +246,7 @@
   .pe-btn__tertiary--btn_small {
   
     @extend %btn;
-  
-    @include pe-btn(
-      $pe-btn-tertiary-bg,
-      $pe-btn-tertiary-text,
-      $pe-btn-tertiary-hover-bg,
-      $pe-btn-tertiary-hover-text
-    );
-  }
-  
-  .pe-btn__tertiary--btn_large {
-  
-    @extend %btn;
+    @extend %btn_small;
   
     @include pe-btn(
       $pe-btn-tertiary-bg,
@@ -318,4 +268,24 @@
       $pe-btn-tertiary-hover-text
     );
   }
+
+// vertical align doesn't work in div and a, the text in those sticks to the top border.
+// It stays at center before because the line height in this file was mistakenly set as height.
+// Here set the line-height in div and a as the same as the height to make text align center.
+  div [class$='--btn_xlarge'], a [class$='--btn_xlarge'] {
+    line-height: 40px !important;
+  }
+
+  div [class$='--btn_large'], a [class$='--btn_large'] {
+    line-height: 36px !important;
+  }
+
+  .pe-btn__primary, .pe-btn__cta, .pe-btn__tertiary, .pe-btn {
+    line-height: 36px !important;
+  }
+  
+  div [class$='--btn_small'], a [class$='--btn_small'] {
+    line-height: 32px !important;
+  }
+  
   

--- a/src/styles/elements/buttons/_buttons.scss
+++ b/src/styles/elements/buttons/_buttons.scss
@@ -89,9 +89,12 @@
     $pe-btn-default-bg,
     $pe-btn-default-text,
     $pe-btn-default-hover-bg,
+    $pe-btn-default-press-bg,
     $pe-btn-default-hover-text,
+    $pe-btn-default-press-text,
     $pe-btn-default-border,
     $pe-btn-default-hover-border,
+    $pe-btn-default-press-border,
     $pe-btn-default-disabled-bg,
     $pe-btn-default-disabled-text
   );
@@ -123,9 +126,12 @@
     $pe-btn-default-bg,
     $pe-btn-default-text,
     $pe-btn-default-hover-bg,
+    $pe-btn-default-press-bg,
     $pe-btn-default-hover-text,
+    $pe-btn-default-press-text,
     $pe-btn-default-border,
     $pe-btn-default-hover-border,
+    $pe-btn-default-press-border,
     $pe-btn-default-disabled-bg,
     $pe-btn-default-disabled-text
   );
@@ -141,9 +147,12 @@
     $pe-btn-default-bg,
     $pe-btn-default-text,
     $pe-btn-default-hover-bg,
+    $pe-btn-default-press-bg,
     $pe-btn-default-hover-text,
+    $pe-btn-default-press-text,
     $pe-btn-default-border,
     $pe-btn-default-hover-border,
+    $pe-btn-default-press-border,
     $pe-btn-default-disabled-bg,
     $pe-btn-default-disabled-text
   );
@@ -156,10 +165,10 @@
   @extend %btn;
 
   @include pe-btn(
-    $pe-color-digital-pearson-blue,
-    $pe-color-white,
-    $pe-color-ink-blue,
-    $pe-color-white
+    $pe-btn-primary-bg,
+    $pe-btn-primary-text,
+    $pe-btn-primary-hover-bg,
+    $pe-btn-primary-press-bg
   );
 }
 
@@ -169,10 +178,10 @@
   @extend %btn_small;
 
   @include pe-btn(
-  $pe-color-digital-pearson-blue,
-  $pe-color-white,
-  $pe-color-ink-blue,
-  $pe-color-white
+    $pe-btn-primary-bg,
+    $pe-btn-primary-text,
+    $pe-btn-primary-hover-bg,
+    $pe-btn-primary-press-bg
   );
 }
 
@@ -182,10 +191,10 @@
   @extend %btn_xlarge;
 
   @include pe-btn(
-  $pe-color-digital-pearson-blue,
-  $pe-color-white,
-  $pe-color-ink-blue,
-  $pe-color-white
+    $pe-btn-primary-bg,
+    $pe-btn-primary-text,
+    $pe-btn-primary-hover-bg,
+    $pe-btn-primary-press-bg
   );
 }
 
@@ -200,7 +209,7 @@
     $pe-btn-cta-bg,
     $pe-btn-cta-text,
     $pe-btn-cta-hover-bg,
-    $pe-btn-cta-hover-text
+    $pe-btn-cta-press-bg
   );
 }
 
@@ -213,7 +222,7 @@
     $pe-btn-cta-bg,
     $pe-btn-cta-text,
     $pe-btn-cta-hover-bg,
-    $pe-btn-cta-hover-text
+    $pe-btn-cta-press-bg
   );
 }
 
@@ -226,7 +235,7 @@
     $pe-btn-cta-bg,
     $pe-btn-cta-text,
     $pe-btn-cta-hover-bg,
-    $pe-btn-cta-hover-text
+    $pe-btn-cta-press-bg
   );
 }
 
@@ -239,7 +248,7 @@
       $pe-btn-tertiary-bg,
       $pe-btn-tertiary-text,
       $pe-btn-tertiary-hover-bg,
-      $pe-btn-tertiary-hover-text
+      $pe-btn-tertiary-press-bg
     );
   }
   
@@ -252,7 +261,7 @@
       $pe-btn-tertiary-bg,
       $pe-btn-tertiary-text,
       $pe-btn-tertiary-hover-bg,
-      $pe-btn-tertiary-hover-text
+      $pe-btn-tertiary-press-bg
     );
   }
  
@@ -265,12 +274,12 @@
       $pe-btn-tertiary-bg,
       $pe-btn-tertiary-text,
       $pe-btn-tertiary-hover-bg,
-      $pe-btn-tertiary-hover-text
+      $pe-btn-tertiary-press-bg
     );
   }
 
 // vertical align doesn't work in div and a, the text in those sticks to the top border.
-// It stays at center before because the line height in this file was mistakenly set as height.
+// It stayed at center before because the line height in this file was mistakenly set as height.
 // Here set the line-height in div and a as the same as the height to make text align center.
   div [class$='--btn_xlarge'], a [class$='--btn_xlarge'] {
     line-height: 40px !important;

--- a/src/styles/elements/buttons/_buttons.scss
+++ b/src/styles/elements/buttons/_buttons.scss
@@ -259,3 +259,54 @@
     $pe-btn-cta-hover-text
   );
 }
+
+//===========TERTIARY=================================
+.pe-btn__tertiary {
+  
+    @extend %btn;
+  
+    @include pe-btn(
+      $pe-btn-tertiary-bg,
+      $pe-btn-tertiary-text,
+      $pe-btn-tertiary-hover-bg,
+      $pe-btn-tertiary-hover-text
+    );
+  }
+  
+  .pe-btn__tertiary--btn_small {
+  
+    @extend %btn;
+  
+    @include pe-btn(
+      $pe-btn-tertiary-bg,
+      $pe-btn-tertiary-text,
+      $pe-btn-tertiary-hover-bg,
+      $pe-btn-tertiary-hover-text
+    );
+  }
+  
+  .pe-btn__tertiary--btn_large {
+  
+    @extend %btn;
+    @extend %btn_large;
+  
+    @include pe-btn(
+      $pe-btn-tertiary-bg,
+      $pe-btn-tertiary-text,
+      $pe-btn-tertiary-hover-bg,
+      $pe-btn-tertiary-hover-text
+    );
+  }
+  
+  .pe-btn__tertiary--btn_xlarge {
+  
+    @extend %btn;
+    @extend %btn_xlarge;
+  
+    @include pe-btn(
+      $pe-btn-tertiary-bg,
+      $pe-btn-tertiary-text,
+      $pe-btn-tertiary-hover-bg,
+      $pe-btn-tertiary-hover-text
+    );
+  }

--- a/src/styles/elements/buttons/_mixins.scss
+++ b/src/styles/elements/buttons/_mixins.scss
@@ -3,6 +3,7 @@
   $color,
   $hover-bg,
   $hover-color,
+  $border: null,
   $hover-border: null,
   $disabled-bg:  null,
   $disabled-color: null
@@ -10,7 +11,7 @@
 
   color           : $color;
   background-color: $bg;
-  border-radius   : $pe-btn-border-radius;
+  border          : $border;
   text-decoration : none;
   text-overflow   : ellipsis;
   white-space     : nowrap;

--- a/src/styles/elements/buttons/_mixins.scss
+++ b/src/styles/elements/buttons/_mixins.scss
@@ -3,6 +3,7 @@
   $color,
   $hover-bg,
   $hover-color,
+  $hover-border: null,
   $disabled-bg:  null,
   $disabled-color: null
 ) {
@@ -20,6 +21,7 @@
   &:focus {
     color            : $hover-color;
     background-color : $hover-bg;
+    border           : $hover-border;
   }
 
   &:disabled,

--- a/src/styles/elements/buttons/_mixins.scss
+++ b/src/styles/elements/buttons/_mixins.scss
@@ -2,9 +2,12 @@
   $bg,
   $color,
   $hover-bg,
-  $hover-color,
+  $press-bg,
+  $hover-color: null,
+  $press-color: null,
   $border: null,
   $hover-border: null,
+  $press-border: null,
   $disabled-bg:  null,
   $disabled-color: null
 ) {
@@ -18,11 +21,16 @@
   overflow        : hidden;
 
   &:hover,
-  &:active,
   &:focus {
     color            : $hover-color;
     background-color : $hover-bg;
     border           : $hover-border;
+  }
+
+  &:active{
+    color            : $press-color;
+    background-color : $press-bg;
+    border           : $press-border;
   }
 
   &:disabled,

--- a/src/styles/elements/buttons/_variables.scss
+++ b/src/styles/elements/buttons/_variables.scss
@@ -2,16 +2,16 @@
 
 $pe-btn-small-height      : 32px !default;
 $pe-btn-small-font-size   : 14px !default;
-$pe-btn-small-padding     : 0 12px !default;
-$pe-btn-small-line-height : 18px !default;
+$pe-btn-small-padding     : 0 30px !default;
+$pe-btn-small-line-height : 0 !default;
 
-$pe-btn-border-radius : 2px !default;
+$pe-btn-border-radius : 22px !default;
 $pe-btn-square-border-radius: 0px !important;
 
-$pe-btn-large-font-size     : 14px !default;
-$pe-btn-large-line-height   : 18px !default;
-$pe-btn-large-padding       : 0 12px !default;
-$pe-btn-large-height        : 36px !default;
+$pe-btn-large-height        : 40px !default;
+$pe-btn-large-font-size     : 16px !default;
+$pe-btn-large-line-height   : 0 !default;
+$pe-btn-large-padding       : 0 30px !default;
 
 $pe-btn-xlarge-height      : 44px !default;
 $pe-btn-xlarge-font-size   : 18px !default;

--- a/src/styles/elements/buttons/_variables.scss
+++ b/src/styles/elements/buttons/_variables.scss
@@ -18,7 +18,6 @@ $pe-btn-xlarge-padding       : 0 20px !default;
 $pe-btn-xlarge-font-size     : 16px !default;
 $pe-btn-xlarge-line-height   : 20px !default;
 
-
 $pe-btn-primary-bg            : $pe-color-digital-pearson-blue !default;
 $pe-btn-primary-text          : $pe-color-white !default;
 $pe-btn-primary-hover-bg      : $pe-color-ink-blue !default;
@@ -45,7 +44,7 @@ $pe-btn-tertiary-text          : $pe-color-graphite !default;
 $pe-btn-tertiary-hover-bg      : darken($pe-color-white-gray, 10%) !default;
 $pe-btn-tertiary-hover-text    : darken($pe-color-graphite, 10%) !default;
 
-// unused border radius in v3.0.0 beta2
+// unused border radius in v3.0.0-beta2
 $pe-btn-border-radius : 22px !default;
 
 $pe-btn-square-border-radius: 0px !important;

--- a/src/styles/elements/buttons/_variables.scss
+++ b/src/styles/elements/buttons/_variables.scss
@@ -13,12 +13,12 @@ $pe-btn-large-font-size     : 16px !default;
 $pe-btn-large-line-height   : 0 !default;
 $pe-btn-large-padding       : 0 30px !default;
 
-/* xlarge size is removed in button v3.0
+// xlarge size is removed in button v3.0
 $pe-btn-xlarge-height      : 44px !default;
 $pe-btn-xlarge-font-size   : 18px !default;
 $pe-btn-xlarge-line-height : 22px !default;
 $pe-btn-xlarge-padding     : 0 20px !default;
-*/
+
 
 $pe-btn-primary-bg            : $pe-color-digital-pearson-blue !default;
 $pe-btn-primary-text          : $pe-color-white !default;
@@ -35,11 +35,7 @@ $pe-btn-default-hover-text    : $pe-color-charcoal !default;
 $pe-btn-default-hover-border  : 1px solid $pe-color-charcoal !default;
 $pe-btn-default-disabled-bg   : $pe-color-moonlight !default;
 $pe-btn-default-disabled-text : $pe-color-concrete !default;
-.pe-btn, .pe-btn--btn_small, .pe-btn--btn_large{
-	&:hover {
-		border: $pe-btn-default-hover-border;
-	}
-}
+
 
 $pe-btn-cta-bg          : $pe-color-sunshine-yellow !default;
 $pe-btn-cta-text        : $pe-color-charcoal !default;

--- a/src/styles/elements/buttons/_variables.scss
+++ b/src/styles/elements/buttons/_variables.scss
@@ -31,21 +31,21 @@ $pe-btn-cta-text        : $pe-color-charcoal !default;
 $pe-btn-cta-hover-bg    : $pe-color-sunflower-yellow !default;
 $pe-btn-cta-hover-text  : $pe-color-charcoal !default;
 
-$pe-btn-default-bg            : $pe-color-white !default;
+$pe-btn-default-bg            : transparent !default;
 $pe-btn-default-text          : $pe-color-graphite !default;
 $pe-btn-default-border        : 1px solid $pe-color-concrete !default;
-$pe-btn-default-hover-bg      : $pe-color-white !default;
-$pe-btn-default-hover-text    : $pe-color-charcoal !default;
-$pe-btn-default-hover-border  : 1px solid $pe-color-charcoal !default;
+$pe-btn-default-hover-bg      : transparent !default;
+$pe-btn-default-hover-text    : darken($pe-color-graphite, 10%) !default;
+$pe-btn-default-hover-border  : 1px solid darken($pe-color-concrete, 10%) !default;
 $pe-btn-default-disabled-bg   : $pe-color-moonlight !default;
 $pe-btn-default-disabled-text : $pe-color-concrete !default;
 
 $pe-btn-tertiary-bg            : $pe-color-white-gray !default;
 $pe-btn-tertiary-text          : $pe-color-graphite !default;
 $pe-btn-tertiary-hover-bg      : darken($pe-color-white-gray, 10%) !default;
-$pe-btn-tertiary-hover-text    : $pe-color-charcoal !default;
+$pe-btn-tertiary-hover-text    : darken($pe-color-graphite, 10%) !default;
 
-
-// unused in button v3.0.0 beta2
+// unused border radius in v3.0.0 beta2
 $pe-btn-border-radius : 22px !default;
+
 $pe-btn-square-border-radius: 0px !important;

--- a/src/styles/elements/buttons/_variables.scss
+++ b/src/styles/elements/buttons/_variables.scss
@@ -1,34 +1,38 @@
 // Buttons //
 
-$pe-btn-small-height      : 32px !default;
-$pe-btn-small-font-size   : 14px !default;
-$pe-btn-small-padding     : 0 30px !default;
-$pe-btn-small-line-height : 0 !default;
+$pe-btn-small-height        : 32px !default;
+$pe-btn-small-border-radius : 32px !default;
+$pe-btn-small-padding       : 0 12px !default;
+$pe-btn-small-font-size     : 14px !default;
+$pe-btn-small-line-height   : 18px !default;
 
-$pe-btn-border-radius : 22px !default;
-$pe-btn-square-border-radius: 0px !important;
+$pe-btn-large-height        : 36px !default;
+$pe-btn-large-border-radius : 36px !default;
+$pe-btn-large-padding       : 0 20px !default;
+$pe-btn-large-font-size     : 14px !default;
+$pe-btn-large-line-height   : 18px !default;
 
-$pe-btn-large-height        : 40px !default;
-$pe-btn-large-font-size     : 16px !default;
-$pe-btn-large-line-height   : 0 !default;
-$pe-btn-large-padding       : 0 30px !default;
-
-// xlarge size is removed in button v3.0
-$pe-btn-xlarge-height      : 44px !default;
-$pe-btn-xlarge-font-size   : 18px !default;
-$pe-btn-xlarge-line-height : 22px !default;
-$pe-btn-xlarge-padding     : 0 20px !default;
+$pe-btn-xlarge-height        : 40px !default;
+$pe-btn-xlarge-border-radius : 40px !default;
+$pe-btn-xlarge-padding       : 0 20px !default;
+$pe-btn-xlarge-font-size     : 16px !default;
+$pe-btn-xlarge-line-height   : 20px !default;
 
 
 $pe-btn-primary-bg            : $pe-color-digital-pearson-blue !default;
 $pe-btn-primary-text          : $pe-color-white !default;
-$pe-btn-primary-hover-bg      : darken($pe-color-digital-pearson-blue, 10%) !default;
+$pe-btn-primary-hover-bg      : $pe-color-ink-blue !default;
 $pe-btn-primary-hover-text    : $pe-color-white !default;
 $pe-btn-primary-disabled-bg   : $pe-color-moonlight !default;
 $pe-btn-primary-disabled-text : $pe-color-concrete !default;
 
+$pe-btn-cta-bg          : $pe-color-sunshine-yellow !default;
+$pe-btn-cta-text        : $pe-color-charcoal !default;
+$pe-btn-cta-hover-bg    : $pe-color-sunflower-yellow !default;
+$pe-btn-cta-hover-text  : $pe-color-charcoal !default;
+
 $pe-btn-default-bg            : $pe-color-white !default;
-$pe-btn-default-text          : #505759 !default;
+$pe-btn-default-text          : $pe-color-graphite !default;
 $pe-btn-default-border        : 1px solid $pe-color-concrete !default;
 $pe-btn-default-hover-bg      : $pe-color-white !default;
 $pe-btn-default-hover-text    : $pe-color-charcoal !default;
@@ -36,13 +40,12 @@ $pe-btn-default-hover-border  : 1px solid $pe-color-charcoal !default;
 $pe-btn-default-disabled-bg   : $pe-color-moonlight !default;
 $pe-btn-default-disabled-text : $pe-color-concrete !default;
 
-
-$pe-btn-cta-bg          : $pe-color-sunshine-yellow !default;
-$pe-btn-cta-text        : $pe-color-charcoal !default;
-$pe-btn-cta-hover-bg    : darken($pe-color-sunshine-yellow, 10%) !default;
-$pe-btn-cta-hover-text  : $pe-color-charcoal !default;
-
 $pe-btn-tertiary-bg            : $pe-color-white-gray !default;
-$pe-btn-tertiary-text          : #505759 !default;
+$pe-btn-tertiary-text          : $pe-color-graphite !default;
 $pe-btn-tertiary-hover-bg      : darken($pe-color-white-gray, 10%) !default;
 $pe-btn-tertiary-hover-text    : $pe-color-charcoal !default;
+
+
+// unused in button v3.0.0 beta2
+$pe-btn-border-radius : 22px !default;
+$pe-btn-square-border-radius: 0px !important;

--- a/src/styles/elements/buttons/_variables.scss
+++ b/src/styles/elements/buttons/_variables.scss
@@ -25,11 +25,12 @@ $pe-btn-primary-hover-text    : $pe-color-white !default;
 $pe-btn-primary-disabled-bg   : $pe-color-moonlight !default;
 $pe-btn-primary-disabled-text : $pe-color-concrete !default;
 
-$pe-btn-default-bg            : $pe-color-moonlight !default;
-$pe-btn-default-text          : $pe-color-charcoal !default;
+$pe-btn-default-bg            : $pe-color-white !default;
+$pe-btn-default-text          : $pe-color-medium-gray !default;
 $pe-btn-default-border        : 1px solid $pe-color-concrete !default;
-$pe-btn-default-hover-bg      : $pe-color-alto !default;
+$pe-btn-default-hover-bg      : $pe-color-white !default;
 $pe-btn-default-hover-text    : $pe-color-charcoal !default;
+$pe-btn-default-hover-border  : 1px solid $pe-color-charcoal !default;
 $pe-btn-default-disabled-bg   : $pe-color-moonlight !default;
 $pe-btn-default-disabled-text : $pe-color-concrete !default;
 
@@ -37,3 +38,8 @@ $pe-btn-cta-bg          : $pe-color-sunshine-yellow !default;
 $pe-btn-cta-text        : $pe-color-charcoal !default;
 $pe-btn-cta-hover-bg    : #FF9A19 !default;
 $pe-btn-cta-hover-text  : $pe-color-charcoal !default;
+
+$pe-btn-tertiary-bg            : $pe-color-white-gray !default;
+$pe-btn-tertiary-text          : $pe-color-medium-gray !default;
+$pe-btn-tertiary-hover-bg      : $pe-color-moonlight !default;
+$pe-btn-tertiary-hover-text    : $pe-color-charcoal !default;

--- a/src/styles/elements/buttons/_variables.scss
+++ b/src/styles/elements/buttons/_variables.scss
@@ -33,6 +33,9 @@ $pe-btn-default-hover-text    : $pe-color-charcoal !default;
 $pe-btn-default-hover-border  : 1px solid $pe-color-charcoal !default;
 $pe-btn-default-disabled-bg   : $pe-color-moonlight !default;
 $pe-btn-default-disabled-text : $pe-color-concrete !default;
+.pe-btn:hover {
+	border: $pe-btn-default-hover-border;
+}
 
 $pe-btn-cta-bg          : $pe-color-sunshine-yellow !default;
 $pe-btn-cta-text        : $pe-color-charcoal !default;

--- a/src/styles/elements/buttons/_variables.scss
+++ b/src/styles/elements/buttons/_variables.scss
@@ -20,29 +20,31 @@ $pe-btn-xlarge-line-height   : 20px !default;
 
 $pe-btn-primary-bg            : $pe-color-digital-pearson-blue !default;
 $pe-btn-primary-text          : $pe-color-white !default;
-$pe-btn-primary-hover-bg      : $pe-color-ink-blue !default;
-$pe-btn-primary-hover-text    : $pe-color-white !default;
-$pe-btn-primary-disabled-bg   : $pe-color-moonlight !default;
-$pe-btn-primary-disabled-text : $pe-color-concrete !default;
+$pe-btn-primary-hover-bg      : #3694af !default;
+$pe-btn-primary-press-bg      : #03617c !default;
 
 $pe-btn-cta-bg          : $pe-color-sunshine-yellow !default;
 $pe-btn-cta-text        : $pe-color-charcoal !default;
-$pe-btn-cta-hover-bg    : $pe-color-sunflower-yellow !default;
-$pe-btn-cta-hover-text  : $pe-color-charcoal !default;
+$pe-btn-cta-hover-bg    : #ffc649  !default;
+$pe-btn-cta-press-bg    : #cc9316  !default;
+
+$pe-btn-tertiary-bg            : $pe-color-moonlight !default;
+$pe-btn-tertiary-text          : $pe-color-graphite !default;
+$pe-btn-tertiary-hover-bg      : #ededed !default;
+$pe-btn-tertiary-press-bg      : #bababa !default;
 
 $pe-btn-default-bg            : transparent !default;
 $pe-btn-default-text          : $pe-color-graphite !default;
 $pe-btn-default-border        : 1px solid $pe-color-concrete !default;
 $pe-btn-default-hover-bg      : transparent !default;
-$pe-btn-default-hover-text    : darken($pe-color-graphite, 10%) !default;
-$pe-btn-default-hover-border  : 1px solid darken($pe-color-concrete, 10%) !default;
+$pe-btn-default-hover-text    : $pe-color-graphite !default;
+$pe-btn-default-hover-border  : 1px solid $pe-color-graphite !default;
+$pe-btn-default-press-bg      : transparent !default;
+$pe-btn-default-press-text    : $pe-color-charcoal !default;
+$pe-btn-default-press-border  : 1px solid $pe-color-charcoal !default;
 $pe-btn-default-disabled-bg   : $pe-color-moonlight !default;
 $pe-btn-default-disabled-text : $pe-color-concrete !default;
 
-$pe-btn-tertiary-bg            : $pe-color-white-gray !default;
-$pe-btn-tertiary-text          : $pe-color-graphite !default;
-$pe-btn-tertiary-hover-bg      : darken($pe-color-white-gray, 10%) !default;
-$pe-btn-tertiary-hover-text    : darken($pe-color-graphite, 10%) !default;
 
 // unused border radius in v3.0.0-beta2
 $pe-btn-border-radius : 22px !default;

--- a/src/styles/elements/buttons/_variables.scss
+++ b/src/styles/elements/buttons/_variables.scss
@@ -22,13 +22,13 @@ $pe-btn-xlarge-padding     : 0 20px !default;
 
 $pe-btn-primary-bg            : $pe-color-digital-pearson-blue !default;
 $pe-btn-primary-text          : $pe-color-white !default;
-$pe-btn-primary-hover-bg      : $pe-color-ink-blue !default;
+$pe-btn-primary-hover-bg      : darken($pe-color-digital-pearson-blue, 10%) !default;
 $pe-btn-primary-hover-text    : $pe-color-white !default;
 $pe-btn-primary-disabled-bg   : $pe-color-moonlight !default;
 $pe-btn-primary-disabled-text : $pe-color-concrete !default;
 
 $pe-btn-default-bg            : $pe-color-white !default;
-$pe-btn-default-text          : $pe-color-medium-gray !default;
+$pe-btn-default-text          : #505759 !default;
 $pe-btn-default-border        : 1px solid $pe-color-concrete !default;
 $pe-btn-default-hover-bg      : $pe-color-white !default;
 $pe-btn-default-hover-text    : $pe-color-charcoal !default;
@@ -39,10 +39,10 @@ $pe-btn-default-disabled-text : $pe-color-concrete !default;
 
 $pe-btn-cta-bg          : $pe-color-sunshine-yellow !default;
 $pe-btn-cta-text        : $pe-color-charcoal !default;
-$pe-btn-cta-hover-bg    : #FF9A19 !default;
+$pe-btn-cta-hover-bg    : darken($pe-color-sunshine-yellow, 10%) !default;
 $pe-btn-cta-hover-text  : $pe-color-charcoal !default;
 
 $pe-btn-tertiary-bg            : $pe-color-white-gray !default;
-$pe-btn-tertiary-text          : $pe-color-medium-gray !default;
-$pe-btn-tertiary-hover-bg      : $pe-color-moonlight !default;
+$pe-btn-tertiary-text          : #505759 !default;
+$pe-btn-tertiary-hover-bg      : darken($pe-color-white-gray, 10%) !default;
 $pe-btn-tertiary-hover-text    : $pe-color-charcoal !default;

--- a/src/styles/elements/buttons/_variables.scss
+++ b/src/styles/elements/buttons/_variables.scss
@@ -13,10 +13,12 @@ $pe-btn-large-font-size     : 16px !default;
 $pe-btn-large-line-height   : 0 !default;
 $pe-btn-large-padding       : 0 30px !default;
 
+/* xlarge size is removed in button v3.0
 $pe-btn-xlarge-height      : 44px !default;
 $pe-btn-xlarge-font-size   : 18px !default;
 $pe-btn-xlarge-line-height : 22px !default;
 $pe-btn-xlarge-padding     : 0 20px !default;
+*/
 
 $pe-btn-primary-bg            : $pe-color-digital-pearson-blue !default;
 $pe-btn-primary-text          : $pe-color-white !default;
@@ -33,8 +35,10 @@ $pe-btn-default-hover-text    : $pe-color-charcoal !default;
 $pe-btn-default-hover-border  : 1px solid $pe-color-charcoal !default;
 $pe-btn-default-disabled-bg   : $pe-color-moonlight !default;
 $pe-btn-default-disabled-text : $pe-color-concrete !default;
-.pe-btn:hover {
-	border: $pe-btn-default-hover-border;
+.pe-btn, .pe-btn--btn_small, .pe-btn--btn_large{
+	&:hover {
+		border: $pe-btn-default-hover-border;
+	}
 }
 
 $pe-btn-cta-bg          : $pe-color-sunshine-yellow !default;

--- a/src/styles/elements/color/_variables.scss
+++ b/src/styles/elements/color/_variables.scss
@@ -13,6 +13,7 @@ $pe-color-digital-ice-blue: #DAF0ED;
 
 // Neutral Palette
 $pe-color-charcoal: #252525;
+$pe-color-graphite: #505759;
 $pe-color-medium-gray: #6A7070;
 $pe-color-concrete: #C7C7C7;
 $pe-color-alto: #D9D9D9;

--- a/src/styles/elements/icons/_icons.scss
+++ b/src/styles/elements/icons/_icons.scss
@@ -16,16 +16,8 @@ svg[class^='pe-icon--'] {
 [class^='pe-btn'] svg[class$='-18'], [class^='pe-btn'] svg[class$='-24'] {
   vertical-align: middle;
   margin-left  : .5em;
+  margin-bottom: .3em;
 }
-
-
-// .pe-btn--btn_large svg[class$='-24'] {
-//   margin-top: 5px;
-// }
-// .pe-btn--btn_xlarge svg[class$='-24'],
-// [class$='--btn_xlarge'] svg[class$='-24'] {
-//   margin-top: 8px;
-// }
 
 svg[class$='-18'] {
   width: 18px;

--- a/src/styles/elements/icons/_icons.scss
+++ b/src/styles/elements/icons/_icons.scss
@@ -13,16 +13,19 @@ svg[class^='pe-icon--'] {
   fill: currentColor;
 }
 
-[class^='pe-btn'] svg[class$='-18'] {
-  vertical-align: text-top;
+[class^='pe-btn'] svg[class$='-18'], [class^='pe-btn'] svg[class$='-24'] {
+  vertical-align: middle;
+  margin-left  : .5em;
 }
-.pe-btn--btn_large svg[class$='-24'] {
-  margin-top: 5px;
-}
-.pe-btn--btn_xlarge svg[class$='-24'],
-[class$='--btn_xlarge'] svg[class$='-24'] {
-  margin-top: 8px;
-}
+
+
+// .pe-btn--btn_large svg[class$='-24'] {
+//   margin-top: 5px;
+// }
+// .pe-btn--btn_xlarge svg[class$='-24'],
+// [class$='--btn_xlarge'] svg[class$='-24'] {
+//   margin-top: 8px;
+// }
 
 svg[class$='-18'] {
   width: 18px;


### PR DESCRIPTION
http://uxframework.pearson.com/c/buttons/beta/

And followings are the final decision on colors/states, if designers didn't get a chance to update the uxf website, please look at these for reference:

SASS solid button state calculations:
- Hover: 20% #fff overlay
- Press: 20% #000 overlay

DEFAULT
* Text:   #505759 (graphite)
* Normal: #c7c7c7 (1px round border, transparent bg)
* Hover:  #505759 (text and border only)
* Press:  #252525 (text and border only) 

PRIMARY 
* Text:   #ffffff (chalk white)
* Normal: #047a9c (4.92 contrast)
* Hover:  #3694af (3.49 contrast)
* Press:  #03617c (6.99 contrast)

SECONDARY (TERTIARY in UXF)
* Text:   #505759 (graphite)
* Normal: #e9e9e9 (6.30 contrast)
* Hover:  #ededed (7.19 contrast)
* Press:  #bababa (6.07 contrast)

CTA 
* Text:   #252525 (charcoal)
* Normal: #ffb81c (8.85 contrast)
* Hover:  #ffc649 (9.80 contrast)	
* Press:  #cc9316 (5.66 contrast)