### PR TITLE
fix: Add additional keyboard functionality

### DIFF
--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -99,8 +99,13 @@ export default class Calendar extends Component {
       e.preventDefault();
     }
 
+    if (which === 13 || which === 32) {
+      e.stopPropagation();
+    }
+
     switch (which) {
       case 13: this.enterSelect(); break;
+      case 32: this.enterSelect(); break;
       case 37: this.leftArrow(); break;
       case 38: this.upArrow(); break;
       case 39: this.rightArrow(); break;

--- a/src/components/TimePicker/TimePicker.js
+++ b/src/components/TimePicker/TimePicker.js
@@ -122,8 +122,8 @@ export default class TimePicker extends Component {
 
 
 TimePicker.defaultProps = {
-  HOURS            : ["1:00 AM","2:00 AM","3:00 AM","4:00 AM","5:00 AM","6:00 AM","7:00 AM","8:00 AM","9:00 AM","10:00 AM","11:00 AM","12:00 PM","1:00 PM","2:00 PM","3:00 PM","4:00 PM","5:00 PM","6:00 PM","7:00 PM","8:00 PM","9:00 PM","10:00 PM","11:00 PM","12:00 AM"],
-  TWENTYFOUR_HOURS : ["01:00","02:00","03:00","04:00","05:00","06:00","07:00","08:00","09:00","10:00","11:00","12:00","13:00","14:00","15:00","16:00","17:00","18:00","19:00","20:00","21:00","22:00","23:00","24:00"],
+  HOURS            : ["6:00 AM","7:00 AM","8:00 AM","9:00 AM","10:00 AM","11:00 AM","12:00 PM","1:00 PM","2:00 PM","3:00 PM","4:00 PM","5:00 PM","6:00 PM","7:00 PM","8:00 PM","9:00 PM","10:00 PM","11:00 PM","12:00 AM","1:00 AM","2:00 AM","3:00 AM","4:00 AM","5:00 AM"],
+  TWENTYFOUR_HOURS : ["06:00","07:00","08:00","09:00","10:00","11:00","12:00","13:00","14:00","15:00","16:00","17:00","18:00","19:00","20:00","21:00","22:00","23:00","24:00","01:00","02:00","03:00","04:00","05:00"],
   inputState: ''
 };
 
@@ -176,6 +176,9 @@ function _listHandler(e) {
 };
 
 function _inputEvents(e) {
+  if (e.altKey && e.which === 40) {
+    this.setState({ displayOpen: !this.state.displayOpen });
+  }
   switch (e.which) {
     case 40:  //down arrow
       e.preventDefault();
@@ -189,6 +192,7 @@ function _inputEvents(e) {
       this.setState({ displayOpen:false, labelStyleTmp:this.state.labelStyle });
       break;
     case 13:
+      e.preventDefault();
       this.setState({ displayOpen: !this.state.displayOpen });
       break;
   };


### PR DESCRIPTION
Addressed a few things that came up in Console's final review for going to Prod with date & timepicker.

Calendar
- Space bar now selects a date.
- added stopPropagation to prevent enter / space selections from bubbling up and conflicting with form submissions.

TimePicker
- Added the option + down arrow keybind to open the TimePicker (same bind as DatePicker)
- Reordered the default time values