### PR TITLE
refactor: Consolidate labelText and timeFormat into one prop

### DIFF
--- a/demo/demoPages/components/InputsPage.js
+++ b/demo/demoPages/components/InputsPage.js
@@ -28,7 +28,8 @@ const InputsPage = (props) => {
     textLabel             : intl.formatMessage(messages.textLabel),
     textPlaceholder       : intl.formatMessage(messages.textPlaceholder),
     textInputInfoMessage  : intl.formatMessage(messages.textInputInfoMessage),
-    textInputErrorMessage : intl.formatMessage(messages.textInputErrorMessage)
+    textInputErrorMessage : intl.formatMessage(messages.textInputErrorMessage),
+    textInputDefaultValue : intl.formatMessage(messages.textInputDefaultValue)
   };
 
   return (

--- a/demo/demoPages/components/TimePickerPage.js
+++ b/demo/demoPages/components/TimePickerPage.js
@@ -70,7 +70,7 @@ class TimePickerPage extends Component {
             infoMessage     = {text.textInputInfoMessage}
             errorMessage    = {text.textInputErrorMessage}
           />
-          <p className="code">{`<TimePicker id = "someGiantId" inputState = "default" labelText = "Select time (hh:mm)" timepickerValue = {this.state.timepickerValue3} changeHandler = {() => console.log("TimePicker-(basic)-changed!!")} infoMessage = "${text.textInputInfoMessage}" errorMessage = "${text.textInputErrorMessage}" />`}</p>
+          <p className="code">{`<TimePicker id = "someGiantId" inputState = "default" labelText = "Select time (hh:mm)" timepickerValue = {this.state.timepickerValue1} changeHandler = {() => console.log("TimePicker-(basic)-changed!!")} infoMessage = "${text.textInputInfoMessage}" errorMessage = "${text.textInputErrorMessage}" />`}</p>
 
           <h2>TimePicker (basic time range): </h2>
           <TimePicker
@@ -91,7 +91,7 @@ class TimePickerPage extends Component {
             infoMessage     = {text.textInputInfoMessage}
             errorMessage    = {text.textInputErrorMessage}
           />
-          <p className="code">{`<TimePicker fancy = {true} id = "someGiantId" inputState = "default" labelText = "Select time (hh:mm)" datepickerValue = {this.state.datepickerValue4} changeHandler = {() => console.log("TimePicker-(basic)-changed!!")} infoMessage = "${text.textInputInfoMessage}" errorMessage = "${text.textInputErrorMessage}" />`}</p>
+          <p className="code">{`<TimePicker fancy = {true} id = "someGiantId" inputState = "default" labelText = "Select time (hh:mm)" timepickerValue = {this.state.datepickerValue3} changeHandler = {() => console.log("TimePicker-(basic)-changed!!")} infoMessage = "${text.textInputInfoMessage}" errorMessage = "${text.textInputErrorMessage}" />`}</p>
 
         </div>
       </div>

--- a/demo/demoPages/components/TimePickerPage.js
+++ b/demo/demoPages/components/TimePickerPage.js
@@ -63,22 +63,20 @@ class TimePickerPage extends Component {
           <h2>TimePicker (basic time): </h2>
           <TimePicker
             id              = "someGiantId1"
-            timeFormat      = "hh:mm"
             inputState      = {inputState}
-            labelText       = "Select time"
+            labelText       = "Select time (hh:mm)"
             timepickerValue = {timepickerValue1}
             changeHandler   = {time => this.setState({ timepickerValue1: time })}
             infoMessage     = {text.textInputInfoMessage}
             errorMessage    = {text.textInputErrorMessage}
           />
-          <p className="code">{`<TimePicker id = "someGiantId" timeFormat = "hh:mm" inputState = "default" labelText = "Select time" timepickerValue = {this.state.timepickerValue3} changeHandler = {() => console.log("TimePicker-(basic)-changed!!")} infoMessage = "${text.textInputInfoMessage}" errorMessage = "${text.textInputErrorMessage}" />`}</p>
+          <p className="code">{`<TimePicker id = "someGiantId" inputState = "default" labelText = "Select time (hh:mm)" timepickerValue = {this.state.timepickerValue3} changeHandler = {() => console.log("TimePicker-(basic)-changed!!")} infoMessage = "${text.textInputInfoMessage}" errorMessage = "${text.textInputErrorMessage}" />`}</p>
 
           <h2>TimePicker (basic time range): </h2>
           <TimePicker
             id              = "someGiantId2"
-            timeFormat      = "hh:mm"
             inputState      = {inputState}
-            labelText       = "Select time"
+            labelText       = "Select time (hh:mm)"
             timepickerValue = {timepickerValue2}
             changeHandler   = {time => this.setState({ timepickerValue2: time })}
             infoMessage     = {text.textInputInfoMessage}
@@ -86,15 +84,14 @@ class TimePickerPage extends Component {
           />
           <TimePicker
             id              = "someGiantId3"
-            timeFormat      = "hh:mm"
             inputState      = {inputState}
-            labelText       = "Select time"
+            labelText       = "Select time (hh:mm)"
             timepickerValue = {timepickerValue3}
             changeHandler   = {time => this.setState({ timepickerValue3: time })}
             infoMessage     = {text.textInputInfoMessage}
             errorMessage    = {text.textInputErrorMessage}
           />
-          <p className="code">{`<TimePicker fancy = {true} id = "someGiantId" dateFormat = "hh:mm" inputState = "default" labelText = "Select time" datepickerValue = {this.state.datepickerValue4} changeHandler = {() => console.log("TimePicker-(basic)-changed!!")} infoMessage = "${text.textInputInfoMessage}" errorMessage = "${text.textInputErrorMessage}" />`}</p>
+          <p className="code">{`<TimePicker fancy = {true} id = "someGiantId" inputState = "default" labelText = "Select time (hh:mm)" datepickerValue = {this.state.datepickerValue4} changeHandler = {() => console.log("TimePicker-(basic)-changed!!")} infoMessage = "${text.textInputInfoMessage}" errorMessage = "${text.textInputErrorMessage}" />`}</p>
 
         </div>
       </div>

--- a/demo/demoPages/components/TimePickerPage.js
+++ b/demo/demoPages/components/TimePickerPage.js
@@ -48,7 +48,7 @@ class TimePickerPage extends Component {
               <li>dateFormat:String === "format for date/time entry"</li>
               <li>inputState:String === "styles for input state, one of 'error','disabled','readOnly','default'"</li>
               <li>labelText:String === "unique lable for the input field"</li>
-              <li>timepickerValue:Date/Time === "value to be displayed by the datepicker/timepicker"</li>
+              <li>timepickerValue:String === "value to be displayed by the timepicker"</li>
               <li>changeHandler:Function === "function to pass values on change"</li>
               <li>infoMessage:String === "an optional info message displayed below the input"</li>
               <li>errorMessage:String === "an optional error message displayed below the input"</li>

--- a/demo/demoPages/components/inputsPageSections/TextInputSection.js
+++ b/demo/demoPages/components/inputsPageSections/TextInputSection.js
@@ -19,6 +19,7 @@ const TextInputSection = (props) => (
           <li>changeHandler:Function(required) === "handles changes"</li>
           <li>infoMessage:String === "an optional info message displayed below the input"</li>
           <li>errorMessage:String === "an optional error message displayed below the input"</li>
+          <li>inputValue:String === "Value of the input field"</li>
         </ul>
       </div>
 
@@ -46,10 +47,10 @@ const TextInputSection = (props) => (
         inputState    = "default"
         changeHandler = {() => {}}
         labelText     = {props.intlDefaultText.textLabel}
-        placeholder   = {props.intlDefaultText.textPlaceholder}
         infoMessage   = {props.intlDefaultText.textInputInfoMessage}
         errorMessage  = {props.intlDefaultText.textInputErrorMessage}
-        />
+        inputValue    = {props.intlDefaultText.textInputDefaultValue}
+      />
       <p className="code">{'<TextInput id="b" fancy={true} inputState="default" changeHandler={() => {}} labelText="First Name" placeholder="First Name" infoMessage="This is an info message" errorMessage="This is an error message"  />'}</p>
 
 

--- a/demo/demoPages/components/inputsPageSections/TextInputSection.js
+++ b/demo/demoPages/components/inputsPageSections/TextInputSection.js
@@ -19,7 +19,7 @@ const TextInputSection = (props) => (
           <li>changeHandler:Function(required) === "handles changes"</li>
           <li>infoMessage:String === "an optional info message displayed below the input"</li>
           <li>errorMessage:String === "an optional error message displayed below the input"</li>
-          <li>value:String === "Value of the input field"</li>
+          <li>value:Any === "Value of the input field"</li>
         </ul>
       </div>
 

--- a/demo/demoPages/components/inputsPageSections/TextInputSection.js
+++ b/demo/demoPages/components/inputsPageSections/TextInputSection.js
@@ -19,7 +19,7 @@ const TextInputSection = (props) => (
           <li>changeHandler:Function(required) === "handles changes"</li>
           <li>infoMessage:String === "an optional info message displayed below the input"</li>
           <li>errorMessage:String === "an optional error message displayed below the input"</li>
-          <li>inputValue:String === "Value of the input field"</li>
+          <li>value:String === "Value of the input field"</li>
         </ul>
       </div>
 
@@ -49,7 +49,7 @@ const TextInputSection = (props) => (
         labelText     = {props.intlDefaultText.textLabel}
         infoMessage   = {props.intlDefaultText.textInputInfoMessage}
         errorMessage  = {props.intlDefaultText.textInputErrorMessage}
-        inputValue    = {props.intlDefaultText.textInputDefaultValue}
+        value         = {props.intlDefaultText.textInputDefaultValue}
       />
       <p className="code">{'<TextInput id="b" fancy={true} inputState="default" changeHandler={() => {}} labelText="First Name" placeholder="First Name" infoMessage="This is an info message" errorMessage="This is an error message"  />'}</p>
 

--- a/demo/translations/defaultMessages.js
+++ b/demo/translations/defaultMessages.js
@@ -53,5 +53,10 @@ export const messages = defineMessages({
     id             : 'textInputErrorMessage',
     description    : 'an optional error message displayed below input',
     defaultMessage : 'This is an error message'
+  },
+  textInputDefaultValue: {
+    id             : 'textInputDefaultValue',
+    description    : 'Default value for an input field',
+    defaultMessage : 'Default Value'
   }
 });

--- a/demo/translations/en-US.json
+++ b/demo/translations/en-US.json
@@ -8,5 +8,6 @@
   "textLabel"             : "First Name",
   "textPlaceholder"       : "First Name",
   "textInputInfoMessage"  : "This is an info message",
-  "textInputErrorMessage" : "This is an error message"
+  "textInputErrorMessage" : "This is an error message",
+  "textInputDefaultValue" : "Default Value"
 }

--- a/demo/translations/fr.json
+++ b/demo/translations/fr.json
@@ -9,5 +9,6 @@
   "textPlaceholder"       : "Prénom",
   "textInputMessage"      : "Ceci est un message d'information",
   "textInputErrorMessage" : "Ceci est un message d'erreur",
-  "copyrightText"         : "French Pearson Education Inc. All Rights Reserved"
+  "copyrightText"         : "French Pearson Education Inc. All Rights Reserved",
+  "textInputDefaultValue" : "Valeur par défaut"
 }

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -27,7 +27,7 @@ class TextInput extends Component {
   render() {
 
     const { labelStyle, inputStyle, spanStyle, passwordStatusText, visibilityStatusText, passwordTypeSelector, butttonStyle, labelFocusStyle, labelStyleTmp  }  = this.state;
-    const { inputState, id, labelText, password, placeholder, infoMessage, errorMessage, changeHandler, inputValue } = this.props;
+    const { inputState, id, labelText, password, placeholder, infoMessage, errorMessage, changeHandler, value } = this.props;
 
     const em = (inputState === 'error' && errorMessage) ? `errMsg-${id} ` : '';
     const ariaDescribedby =  em + ((infoMessage) ? `infoMsg-${id}` : '');
@@ -48,7 +48,7 @@ class TextInput extends Component {
           onFocus          = {() => this.setState({labelStyleTmp:labelFocusStyle})}
           onBlur           = {() => this.setState({labelStyleTmp:labelStyle})}
           onChange         = { changeHandler }
-          value            = {inputValue}
+          value            = {value}
         />
 
         {(inputState  !== 'readOnly' || inputState !== 'disabled') && <span className={spanStyle} />}
@@ -76,11 +76,11 @@ TextInput.propTypes = {
   errorMessage       : PropTypes.string,
   fancy              : PropTypes.bool,
   password           : PropTypes.bool,
-  inputValue         : PropTypes.string.isRequired
+  value         : PropTypes.string.isRequired
 };
 
 TextInput.defaultProps = {
-  inputValue: ''
+  value: ''
 }
 
 

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -76,13 +76,12 @@ TextInput.propTypes = {
   errorMessage       : PropTypes.string,
   fancy              : PropTypes.bool,
   password           : PropTypes.bool,
-  value         : PropTypes.string.isRequired
+  value : PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.object,
+    PropTypes.string
+  ])
 };
-
-TextInput.defaultProps = {
-  value: ''
-}
-
 
 function _togglePassword() {
   const { passwordTypeSelector, passwordStatusText } = this.state;

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -27,7 +27,7 @@ class TextInput extends Component {
   render() {
 
     const { labelStyle, inputStyle, spanStyle, passwordStatusText, visibilityStatusText, passwordTypeSelector, butttonStyle, labelFocusStyle, labelStyleTmp  }  = this.state;
-    const { inputState, id, labelText, password, placeholder, infoMessage, errorMessage, changeHandler } = this.props;
+    const { inputState, id, labelText, password, placeholder, infoMessage, errorMessage, changeHandler, inputValue } = this.props;
 
     const em = (inputState === 'error' && errorMessage) ? `errMsg-${id} ` : '';
     const ariaDescribedby =  em + ((infoMessage) ? `infoMsg-${id}` : '');
@@ -48,7 +48,8 @@ class TextInput extends Component {
           onFocus          = {() => this.setState({labelStyleTmp:labelFocusStyle})}
           onBlur           = {() => this.setState({labelStyleTmp:labelStyle})}
           onChange         = { changeHandler }
-          />
+          value            = {inputValue}
+        />
 
         {(inputState  !== 'readOnly' || inputState !== 'disabled') && <span className={spanStyle} />}
         {password     && <span><button type="button" className={butttonStyle} id={`showbutton-${id}`} onClick={this.togglePassword} disabled={inputState === 'disabled'}>{passwordStatusText}</button> <span aria-live="polite" aria-atomic="true" className="pe-sr-only">{visibilityStatusText}</span></span>}
@@ -74,8 +75,13 @@ TextInput.propTypes = {
   infoMessage        : PropTypes.string,
   errorMessage       : PropTypes.string,
   fancy              : PropTypes.bool,
-  password           : PropTypes.bool
+  password           : PropTypes.bool,
+  inputValue         : PropTypes.string.isRequired
 };
+
+TextInput.defaultProps = {
+  inputValue: ''
+}
 
 
 function _togglePassword() {

--- a/src/components/TimePicker/TimePicker.js
+++ b/src/components/TimePicker/TimePicker.js
@@ -51,8 +51,8 @@ export default class TimePicker extends Component {
 
     const { inputStyle, labelStyleTmp, displayOpen, timepickerValue,
             containerStyle, placeholder } = this.state;
-    const { className, inputState, id, labelText, timeFormat, infoMessage,
-            errorMessage, twentyFourHour, TWENTYFOUR_HOURS, HOURS, disableLabel
+    const { className, inputState, id, labelText, infoMessage, errorMessage,
+            twentyFourHour, TWENTYFOUR_HOURS, HOURS, disableLabel
           } = this.props;
 
     const em                  = (inputState === 'error' && errorMessage) ? `errMsg-${id} ` : '';
@@ -70,7 +70,7 @@ export default class TimePicker extends Component {
         ref={(dom) => this.container = dom}
       >
         <label className={`${labelStyleTmp}${labelCheck}`} htmlFor={id}>
-          {`${labelText} (${timeFormat})`}
+          {labelText}
         </label>
 
         <div className={containerStyle}>
@@ -131,7 +131,6 @@ TimePicker.defaultProps = {
 TimePicker.propTypes = {
   id               : PropTypes.string.isRequired,
   labelText        : PropTypes.string.isRequired,
-  timeFormat       : PropTypes.string.isRequired,
   changeHandler    : PropTypes.func.isRequired,
   infoMessage      : PropTypes.string,
   errorMessage     : PropTypes.string,


### PR DESCRIPTION
- labelText and timeFormat were both being used to make up the label.  Consolidated into one to eliminate the amount of props you need and allow complete control over the label.  The ( ) were hard coded in the component so if nothing was passed to timeFormat you'd have undefined displayed or just empty parenthesis.

- Added in value prop for TextInput component.

This would require a minor version for the TimePicker change, but I can reach out to Console and give them a heads up.

In addition this should address the first part of Issue #43 .  The second part shouldn't be an issue. `defaultValue` on the `<select />` is handled by the `selectedOption` prop and shouldn't require any additional changes.