### PR TITLE
fix: type=button back on imageButton case

### DIFF
--- a/src/components/Dropdown/DropdownItem.js
+++ b/src/components/Dropdown/DropdownItem.js
@@ -73,6 +73,7 @@ export default class DropdownItem extends Component {
               key={dropdownId + selectValue}
 			      >
 				      <button role="menuitem"
+                type="button"
 					      className={checkmark ? 'checkmark' : ''}
 					      tabIndex="-1">
 						    {checkmark ?

--- a/src/components/Dropdown/DropdownItem.js
+++ b/src/components/Dropdown/DropdownItem.js
@@ -48,6 +48,7 @@ export default class DropdownItem extends Component {
             key={dropdownId + selectValue}
 			    >
             <button role="menuitem"
+              type="button"
 				      className={checkmark ? 'checkmark' : ''}
 				      tabIndex="-1">
 				      {checkmark ?


### PR DESCRIPTION
`type="button"` was taken off this particular button in the `case 'imageButton'` and needs to be added back.  Without it the button will default to `type="submit"`.