### PR TITLE
Tabs

### DIFF
--- a/demo/demoPages/components/TabsPage.js
+++ b/demo/demoPages/components/TabsPage.js
@@ -15,7 +15,7 @@ const TabsPage = () => (
     <h2><a href="http://pearson-higher-ed.github.io/design/c/tab-navigation/beta/">Tabs</a></h2>
     <div className="elementContainer">
       <Tabs
-        callback={testHandler}
+        callback={testHandler} bar
       >
         <Pane label="Tabby">
           <div style={pad}>A bunch of words in Tab 1</div>
@@ -30,7 +30,7 @@ const TabsPage = () => (
 
       <h3>Example usage</h3>
         <p className="code">
-          {`<Tabs>`} <br/>
+          {`<Tabs bar>`} <br/>
           <div style={eight}>{`<Pane label="Tabby">`} <br/> </div>
           <div style={sixteen}>{`<div>Tab 1</div>`} <br/> </div>
           <div style={eight}>{`</Pane>`} <br/> </div>
@@ -59,6 +59,8 @@ const TabsPage = () => (
           <li className="li-props">light:Boolean === {`<Tabs light>`}</li>
           <li className="li-props">The light prop can be used to provide contrast
           on a darker background. <br/>Defaults to false.</li>
+          <li className="li-props">bar:Boolean === {`<Tabs bar>`}</li>
+          <li className="li-props">The bar prop can be used to provide bar style tabs. <br/>Defaults to false.</li>
         </ul>
 
         <h3>Pane Props</h3>

--- a/src/components/Tabs/Pane.js
+++ b/src/components/Tabs/Pane.js
@@ -16,7 +16,11 @@ export default class Pane extends Component {
   render() {
 
     return (
-      <div role="tabpanel" aria-describedby={this.context.id}>
+      <div
+        id={this.context.panelid}
+        role="tabpanel" 
+        aria-labelledby={this.context.tabid}
+        tabIndex="0">
         {this.props.children}
       </div>
     )
@@ -24,5 +28,6 @@ export default class Pane extends Component {
 }
 
 Pane.contextTypes = {
-  id: PropTypes.string
+  tabid: PropTypes.string,
+  panelid: PropTypes.string
 }

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -25,17 +25,17 @@ export default class Tabs extends Component {
 
     this.state = {
       selected: this.props.selected,
-      tabId: ''
+      tabId: '',
+      panelId: ''
     }
   };
 
   getChildContext() {
-    return { id: this.state.tabId };
+    return { tabid: this.state.tabId.concat('', this.state.selected),
+             panelid: this.state.panelId.concat('', this.state.selected) };
   }
 
   handleClick(i, event) {
-    event.preventDefault();
-
     if (this.props.callback !== undefined) {
       this.props.callback(i);
     }
@@ -81,28 +81,27 @@ export default class Tabs extends Component {
   renderLabels() {
     function labels(child, i) {
       let activeClass = this.state.selected === i ? 'activeTab' : '';
-      let tabI = activeClass ? "0" : "-1";
+      let tabI = activeClass ? null : '-1';
       let ariaSelected = activeClass ? true : false;
       const themeCheck = this.props.light ? 'light' : '';
 
       return (
-        <li key={i} role="presentation" onFocus={() => this.setState({ tabId: `_${uuid.v1()}`})}>
-          <a href="#"
-             role="tab"
-             id={this.state.tabId}
-             tabIndex={tabI}
-             aria-selected={ariaSelected}
-             className={`pe-label ${themeCheck} ${activeClass}`}
-             onClick={this.handleClick.bind(this, i)}>
-               {child.props.label}
-          </a>
-        </li>
+        <button onFocus={() => this.setState({ tabId: num+`_${uuid.v1()}`,  panelId: num+`_${uuid.v4()}`})}
+          className={`pe-tabs--btn ${themeCheck} ${activeClass}`} 
+          id={this.state.tabId+i} 
+          role="tab"
+          tabIndex={tabI}
+          aria-controls={this.state.panelId+i} 
+          aria-selected={ariaSelected}
+          onClick={this.handleClick.bind(this, i)}
+          >{child.props.label}  
+        </button>
       );
     }
     return (
-      <ul className="tabs__labels" role="tablist" ref={(ul) => { this.doc = ul; }}>
+      <div className="pe-tabs" role="tablist" ref={(div) => { this.doc = div; }} onFocus={() => this.setState({ tabId: `_${uuid.v1()}`,  panelId: `_${uuid.v4()}`})}>
         {this.props.children.map(labels.bind(this))}
-      </ul>
+      </div>
     );
   }
 
@@ -126,5 +125,6 @@ export default class Tabs extends Component {
 };
 
 Tabs.childContextTypes = {
-  id: PropTypes.string
+  tabid: PropTypes.string,
+  panelid: PropTypes.string
 }

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -12,7 +12,8 @@ export default class Tabs extends Component {
       PropTypes.array,
       PropTypes.element
     ]).isRequired,
-    light: PropTypes.bool
+    light: PropTypes.bool,
+    bar: PropTypes.bool
   }
 
   static defaultProps = {
@@ -35,7 +36,7 @@ export default class Tabs extends Component {
              panelid: this.state.panelId.concat('', this.state.selected) };
   }
 
-  handleClick(i, event) {
+  handleClick(i) {
     if (this.props.callback !== undefined) {
       this.props.callback(i);
     }
@@ -54,19 +55,19 @@ export default class Tabs extends Component {
       const selectedIndex = this.state.selected;
       if (selectedIndex === 0 && event.keyCode === 37) {
         tabArray[lastTabArray].focus();
-        this.setState({ selected: lastTabArray });
       }
       if (selectedIndex === lastTabArray && event.keyCode === 39) {
         tabArray[0].focus();
-        this.setState({ selected: 0 });
       }
       if (selectedIndex !== 0 && event.keyCode === 37) {
         tabArray[selectedIndex - 1].focus();
-        this.setState({ selected: selectedIndex - 1 });
       }
       if (selectedIndex !== lastTabArray && event.keyCode === 39) {
         tabArray[selectedIndex + 1].focus();
-        this.setState({ selected: selectedIndex + 1 });
+      }
+      if (event.keyCode === 13 || 32) {
+        const current = tabArray.indexOf(event.target);
+        this.setState({ selected: current });
       }
     }, true)
 
@@ -83,11 +84,10 @@ export default class Tabs extends Component {
       let activeClass = this.state.selected === i ? 'activeTab' : '';
       let tabI = activeClass ? null : '-1';
       let ariaSelected = activeClass ? true : false;
-      const themeCheck = this.props.light ? 'light' : '';
-
+      
       return (
         <button onFocus={() => this.setState({ tabId: num+`_${uuid.v1()}`,  panelId: num+`_${uuid.v4()}`})}
-          className={`pe-tabs--btn ${themeCheck} ${activeClass}`} 
+          className={`pe-tabs--btn ${activeClass}`} 
           id={this.state.tabId+i} 
           role="tab"
           tabIndex={tabI}
@@ -98,8 +98,9 @@ export default class Tabs extends Component {
         </button>
       );
     }
+    const themeCheck = this.props.light ? 'light' : this.props.bar ? 'bar': '';
     return (
-      <div className="pe-tabs" role="tablist" ref={(div) => { this.doc = div; }} onFocus={() => this.setState({ tabId: `_${uuid.v1()}`,  panelId: `_${uuid.v4()}`})}>
+      <div className={`pe-tabs ${themeCheck}`} role="tablist" ref={(div) => { this.doc = div; }} onFocus={() => this.setState({ tabId: `_${uuid.v1()}`,  panelId: `_${uuid.v4()}`})}>
         {this.props.children.map(labels.bind(this))}
       </div>
     );

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -1,57 +1,23 @@
-.tabs__labels {
-  margin: 0;
-  padding: 0;
-}
+@import '../../styles/elements.scss';
+.pe-tabs {
+  background-color: $pe-color-white-gray;
+  border-bottom: solid 1px $pe-color-moonlight;
 
-.tabs__labels li {
-  &:first-child {
-    padding-left: 0;
-  }
-  &:last-child {
-    padding-right: 0;
-  }
-  display: inline-block;
-  padding: 0 16px;
-  margin: 0;
-}
+  .pe-tabs--btn {
+    border: 0;
+    background-color: transparent;
 
-%tab-abstract {
-  padding: 8px 0;
-  display: block;
-  text-decoration: none;
-  border-bottom: 3px solid transparent;
-}
+    @extend .pe-label;
 
-.tabs__labels li a {
-  @extend %tab-abstract;
-  color: #6A7070;
+    padding: 8px 0;
+    margin: 4px 16px -1px 16px;
 
-  &:hover,
-  &:focus {
-    color: #252525;
-    border-bottom: 3px solid #C7C7C7;
-  }
-}
+    &[aria-selected="true"], &[aria-selected="true"]:hover, &[aria-selected="true"]:focus {
+      border-bottom: solid 3px $pe-color-digital-marine-turquoise;
+    }
 
-.tabs__labels li a.light {
-  @extend %tab-abstract;
-  color: #D9D9D9;
-
-  &:hover {
-    color: #FFF;
-    border-bottom: 3px solid #D9D9D9;
-  }
-}
-
-.tabs__labels li a.light.activeTab {
-  color: #FFF;
-}
-
-.tabs__labels li a.activeTab {
-  border-bottom-color: #19A6A4;
-  color: #252525;
-
-  &:hover {
-    border-bottom: 3px solid #19A6A4;
+    &:hover, &:focus {
+      border-bottom: solid 3px $pe-color-concrete;
+    }
   }
 }

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -1,8 +1,6 @@
 @import '../../styles/elements.scss';
-.pe-tabs {
-  background-color: $pe-color-white-gray;
-  border-bottom: solid 1px $pe-color-moonlight;
 
+.pe-tabs {
   .pe-tabs--btn {
     border: 0;
     background-color: transparent;
@@ -12,12 +10,29 @@
     padding: 8px 0;
     margin: 4px 16px -1px 16px;
 
+    &:not([aria-selected="true"]):hover, &:not([aria-selected="true"]):focus {
+      border-bottom: solid 3px $pe-color-concrete;
+    }
+
     &[aria-selected="true"], &[aria-selected="true"]:hover, &[aria-selected="true"]:focus {
       border-bottom: solid 3px $pe-color-digital-marine-turquoise;
     }
+  }
+}
 
-    &:hover, &:focus {
-      border-bottom: solid 3px $pe-color-concrete;
+.pe-tabs.bar {
+  background-color: $pe-color-white-gray;
+  border-bottom: solid 1px $pe-color-moonlight;
+}
+
+.pe-tabs.light {
+  .pe-tabs--btn {
+    color: $pe-color-white;
+
+    &:not([aria-selected="true"]):hover, &:not([aria-selected="true"]):focus {
+      border-bottom: solid 3px $pe-color-alto;
     }
   }
 }
+
+


### PR DESCRIPTION
Refactor tab navigation to improve a11y and add more styles:

1. Use button other than list & link to build tabs.
2. Allow users to use left/right key to navigate through tabs while not activating them.
3. Tabs are activated only by click/enter key/space key.
4. Add one more prop for bar style tab navigation.