### PR TITLE
Focus styles unstable

### DIFF
--- a/src/styles/base/_mixins.scss
+++ b/src/styles/base/_mixins.scss
@@ -23,7 +23,7 @@
 	outline: 2px solid $pe-focus-color;
 	outline-offset: 4px;
 }
-@mixin focusPseudoOutline($radius: 4px, $widthOffset: 10px, $heightOffset: 10px, $top: -6px, $left: -6px) {
+@mixin focusPseudoOutline($radius: 4px, $widthOffset: 8px, $heightOffset: 8px, $top: -6px, $left: -6px) {
         &:after {
           border: 2px solid $pe-focus-color;
           content: "";

--- a/src/styles/elements/buttons/_mixins.scss
+++ b/src/styles/elements/buttons/_mixins.scss
@@ -31,7 +31,7 @@
     border			 : $border-hover;
     outline: 0;
     
-    @include focusPseudoOutline();
+    @include focusPseudoOutline($radius: $pe-btn-border-radius, $widthOffset: 12px, $heightOffset: 12px, $top: -6px, $left: -6px);
     
    }
 
@@ -47,10 +47,11 @@
   }
    //====== overflow moved to a span inside btn to accomodate focus outline ======
   span {
-  	display         : block;
+  	display         : inline-block;
   	max-width       : 100%;
   	text-overflow   : ellipsis;
     white-space     : nowrap;
     overflow        : hidden;
+    vertical-align  : middle;
   }
 }


### PR DESCRIPTION
@antelopeb 
For some reason, the buttons had the square focus outline. I must have messed up when I copied files over from master. I just updated the button border radius and fixed an issue the span overflow caused in my GLP Proto.