### PR TITLE
dropdown fix for mobile wrapper taking up space

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -437,7 +437,7 @@ export default class Dropdown extends Component {
             curParent = menu.parentElement
         placeholder.setAttribute("id", fakeId),
         placeholder.setAttribute("style", "display:none;")
-        divWrapper.className = "dropdown-wrapper"
+        divWrapper.className = "dropdown-mobile-wrapper"
         divContainer.className = "dropdown-container"
 
         // insert a placeholder

--- a/src/components/Dropdown/Dropdown_fullView.scss
+++ b/src/components/Dropdown/Dropdown_fullView.scss
@@ -1,3 +1,6 @@
+.dropdown-mobile-wrapper {
+  display:none;
+}
 .dropdown-activator {
   cursor: pointer;
 }

--- a/src/components/Dropdown/Dropdown_mobile.scss
+++ b/src/components/Dropdown/Dropdown_mobile.scss
@@ -2,11 +2,14 @@
 .dropdown-mobile-wrapper {
 	overflow:hidden;
 	display:unset;
+	.dropdown-container {
+		display:unset;
+	}
 }
   .dropdown-container {
     width: 100%;
     height: 100%;
-    display:unset;
+    
 
     ul {
       box-sizing: border-box;

--- a/src/components/Dropdown/Dropdown_mobile.scss
+++ b/src/components/Dropdown/Dropdown_mobile.scss
@@ -1,7 +1,12 @@
 @media only screen and (max-device-width: 767px) {
+.dropdown-mobile-wrapper {
+	overflow:hidden;
+	display:unset;
+}
   .dropdown-container {
     width: 100%;
     height: 100%;
+    display:unset;
 
     ul {
       box-sizing: border-box;


### PR DESCRIPTION
*changed mobile wrapper class to dropdown-mobile-wrapper to not conflict with dropdown-wrapper class used in the demo page header
*specified .dropdown-mobile-wrapper. > .dropdown-container class as display:unset on mobile. The display inline-block was causing it to take up some height space for some reason. Didn't want to remove that dropdown-container property in case it cause layout issues for the button placement.
Let me know what you think!