### PR TITLE
make focus catchall have less precedence

### DIFF
--- a/src/styles/base/_html-tags.scss
+++ b/src/styles/base/_html-tags.scss
@@ -246,17 +246,17 @@ kbd {
 }
 
 //==== generic focus override =======
-a[href]:not([tabindex^="-"]):not([inert]),
-area[href]:not([tabindex^="-"]):not([inert]),
-input:not([disabled]):not([inert]),
-select:not([disabled]):not([inert]),
-textarea:not([disabled]):not([inert]),
-button:not([disabled]):not([inert]),
-iframe:not([tabindex^="-"]):not([inert]),
-audio:not([tabindex^="-"]):not([inert]),
-video:not([tabindex^="-"]):not([inert]),
-[contenteditable]:not([tabindex^="-"]):not([inert]),
-[tabindex]:not([tabindex^="-"]):not([inert]) {
+a[href]:not([tabindex^="-"]),
+area[href]:not([tabindex^="-"]),
+input,
+select,
+textarea,
+button,
+iframe:not([tabindex^="-"]),
+audio:not([tabindex^="-"]),
+video:not([tabindex^="-"]),
+[contenteditable]:not([tabindex^="-"]),
+[tabindex]:not([tabindex^="-"]) {
   &:focus {
     @include focusOutline;
   }


### PR DESCRIPTION
Removed attributes to the focus catchall has less precedence over the elements' styling.

@whatevers  - the :not disabled was conflicting with some things so I removed it as well. Let me know if you see any issue with this update. Thanks!