### PR TITLE
Fixed calendar to display sixth row in GMT

### DIFF
--- a/src/components/Calendar/components/Dates.js
+++ b/src/components/Calendar/components/Dates.js
@@ -31,7 +31,7 @@ const Dates = (props) => {
   const startDay = firstOfMonth.getUTCDay();
   const first = firstOfMonth.getDay();
   const janOne = new Date(year, 0, 1);
-  let rows = 5;
+  let rows = 6;
 
   if (startDay === 5 && daysInMonth === 31 || startDay === 6 && daysInMonth > 29) rows = 6;
   if (startDay === 0 && daysInMonth === 28) rows = 4;


### PR DESCRIPTION
I can't believe this @antelopeb. I think I figured this out without any help, woot! Woot!

Here is a screenshot of the bug reproduced. Filename shows GMT time, also I changed my location in Chrome Dev Tools (console/sensor):
![screen shot 2018-10-05 at 1 21 42 am](https://user-images.githubusercontent.com/9653426/46512288-e9f0d180-c807-11e8-9fa5-88a21ed8d8b5.jpg)


Here is a screenshot of the bug fixed in GMT:
![screen shot 2018-10-05 at 2 30 26 am](https://user-images.githubusercontent.com/9653426/46512312-10167180-c808-11e8-8cae-e68b025d3ab9.jpg)

Here are screenshots for an entire year in GMT Timezone:
https://drive.google.com/drive/folders/1MU3RD1bo0zIHxZOnwnr8bQysvUwL4w6I

