### PR TITLE
fix: setting pe-btn* focus indicator

### DIFF
--- a/src/styles/elements/buttons/_mixins.scss
+++ b/src/styles/elements/buttons/_mixins.scss
@@ -26,7 +26,7 @@
     color            : $hover-color;
     background-color : $hover-bg;
     border			 : $border-hover;
-    outline          : 0;
+      @include focusOutline;
       @include focusPseudoOutline(4px, 8px, 8px, -6px, -6px);
    }
   


### PR DESCRIPTION
Setting the outline for pe-btn*:focus to match what is for the base <button>