### PR TITLE
ELEWC-3760 Snyk Setup. Remove unnecessary dependency of npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "babel-runtime": "^6.26.0",
     "input-format": "^0.1.15",
     "libphonenumber-js": "^0.4.42",
-    "npm": "^6.4.1",
     "react-responsive-ui": "^0.10.44"
   },
   "devDependencies": {


### PR DESCRIPTION
Removal of npm as a dependency.  This is creating false positive security vulnerabilities when scanning with Snyk.