### PR TITLE
Corrected errors in use of the aria-describedby attribute.

### DIFF
--- a/src/components/PhoneNumber/components/Input.js
+++ b/src/components/PhoneNumber/components/Input.js
@@ -1009,7 +1009,7 @@ export default class Input extends Component
 
 		const imgBaseUrl = 'https://pearsonux.sfo2.cdn.digitaloceanspaces.com/flags/';
 		const phoneCodeLabel = country_select_is_shown ? 'rrui-input__intlCode--disabled' : 'rrui-input__intlCode';
-		const ariaDescribedbyInput =  id + 'phoneNumberInfo ' + id + 'phoneNumberError';
+		const ariaDescribedbyInput =  id + 'phoneNumberError';
 		const selectLabelAria = selectAriaLabel ? selectAriaLabel + ' screen readers, skip to ' + labelText : 'Select country screen readers, skip to ' + labelText;
 		const fancyGroup = fancy ? 'rrui__buttonCodeGroup' : 'rrui__buttonCodeGroup-basic';
 		const intFlagUrl = 'https://pearsonux.sfo2.cdn.digitaloceanspaces.com/flags/Flag_of_the_United_Nations.svg';
@@ -1017,6 +1017,7 @@ export default class Input extends Component
 		let errorMsg = indicateInvalid && validNumber ? error : 'Invalid Number';
 		let underlineSpan = fancy ? (<span className='pe-input_underline'></span>) : '';
 		let useFancy = fancy ? 'pe-textInput rrui-input__padding' : 'pe-textInput--basic';
+		let conditionalAttributes = {};
 
 		errorMsg = inputDirty ? errorMsg : '';
 
@@ -1033,6 +1034,9 @@ export default class Input extends Component
 			inputStyle.marginTop = '0px';
 		}
 
+		if (errorMsg) {
+			conditionalAttributes['aria-describedby'] = ariaDescribedbyInput;
+		}
 
 		// `type="tel"` was reported to have issues with
 		// Samsung keyboards caret position on Android OS.
@@ -1103,7 +1107,7 @@ export default class Input extends Component
 								style={ inputStyle }
 								metadata={ metadata }
 								className={ useFancy }
-								aria-describedby={ ariaDescribedbyInput }
+								{ ...conditionalAttributes }
 								/>
 								{ underlineSpan }
 							</div>


### PR DESCRIPTION
There's an element in the phone number picker that specifies an aria-describedby attribute with two IDs in it- one for an element that _never_ exists within the component (and which component consumers cannot be expected to know anything about, as this is undocumented) and the other which only _sometimes_ exists (conditional on whether errors have been reported for the input).

This change removes the ID of the element which never exists from the aria-describedby attribute in question and updated that attribute itself to be conditionally rendered according to the same condition as the error message element whose ID it specifies. This ensures that the aria-describedby attribute never actively refers to an element which does not currently exist within the DOM.